### PR TITLE
Contract error metadata collection and lint tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ ifeq ($(TARGET),)
   TARGET:=${DEFAULT_TARGET}
 endif
 
+# The environment variable TEIA_SC_PARAMS holds flags separated by ':' which
+# can be used to control metadata and test features. Leaving this blank should
+# cause contracts to run without the teia_sc package. This should not affect
+# the smart contract Michelson code output. It may however affect metadata.
+# Typical use: 
+# 'tzip16_error_inline' - turns on in-contract error script
+# 'tzip16_error_lint' - turns on additional tests and lint report for tzip16 errors
+ifeq ($(TEIA_SC_PARAMS),)
+  export TEIA_SC_PARAMS:=tzip16_error_inline:tzip16_error_lint
+endif
+
 export PYTHONPATH:=.:$(PYTHONPATH)
 
 # Contracts source

--- a/python/contracts/daoGovernance.py
+++ b/python/contracts/daoGovernance.py
@@ -1,4 +1,5 @@
 import smartpy as sp
+from teia_sc.error_collection import ErrorCollection
 
 
 class DAOGovernance(sp.Contract):
@@ -174,6 +175,9 @@ class DAOGovernance(sp.Contract):
             # The number of token editions
             amount=sp.TNat).layout(("to_", ("token_id", "amount"))))).layout(
                 ("from_", "txs")))
+
+    # Start a collection for smart contract errors
+    error_collection = ErrorCollection(__qualname__).inject_into_smartpy(sp)
 
     def __init__(self, metadata, administrator, treasury, token,
                  representatives, guardians, quorum, governance_parameters):

--- a/python/contracts/daoToken.py
+++ b/python/contracts/daoToken.py
@@ -47,7 +47,7 @@ class DAOToken(sp.Contract):
             ("level", "balance"))
 
     # Start a collection for smart contract errors
-    error_collection = ErrorCollection(__qualname__).inject(sp)
+    error_collection = ErrorCollection(__qualname__).inject_into_smartpy(sp)
 
     # Set a shorthand wrapper function to reference and add error info.
     @staticmethod

--- a/python/contracts/daoToken.py
+++ b/python/contracts/daoToken.py
@@ -51,11 +51,11 @@ class DAOToken(sp.Contract):
 
     # Set a shorthand wrapper function to reference and add error info.
     @staticmethod
-    def _add_error(*args, **kwargs):
+    def _tzip16_error(*args, **kwargs):
         "Helper method to collect metadata for errors"
         # All failwith errors return the same type for this contract:
         kwargs.update(failwith_type='string', expansion_type='string')
-        return DAOToken.error_collection.add_error(*args, **kwargs)
+        return DAOToken.error_collection.add_tzip16_error(*args, **kwargs)
 
     def __init__(self, administrator, metadata, token_metadata, max_supply, max_share):
         """Initializes the contract.
@@ -106,36 +106,36 @@ class DAOToken(sp.Contract):
             max_share_exceptions=sp.set([]),
             proposed_administrator=sp.none)
 
-        # A function handle to wrap calls to error_collection.add_error()
-        add_error = DAOToken._add_error
+        # A function handle to wrap calls to error_collection.add_tzip16_error()
+        tzip16_error = DAOToken._tzip16_error
 
-        # Contract error codes, messages for expansion and documentation.
-        add_error("FA2_NOT_ADMIN",
+        # Contract error codes, messages for wallet expansion and documentation.
+        tzip16_error("FA2_NOT_ADMIN",
          expansion = "The caller must be the contract administrator.",
          doc       = """Only the contract administrator can perform these operations:
 mint, transfer_administrator, set_metadata, add_max_share_exception""")
-        add_error("FA2_NOT_OPERATOR",
+        tzip16_error("FA2_NOT_OPERATOR",
           expansion="",
           )
-        add_error("FA2_SENDER_IS_NOT_OWNER",
+        tzip16_error("FA2_SENDER_IS_NOT_OWNER",
           expansion="",
           )
-        add_error("FA2_SHARE_EXCESS",
+        tzip16_error("FA2_SHARE_EXCESS",
           expansion="",
           )
-        add_error("FA2_SUPPLY_EXCEEDED",
+        tzip16_error("FA2_SUPPLY_EXCEEDED",
           expansion="",
           )
-        add_error("FA2_TOKEN_UNDEFINED",
+        tzip16_error("FA2_TOKEN_UNDEFINED",
           expansion="",
           )
-        add_error("FA2_WRONG_LEVEL",
+        tzip16_error("FA2_WRONG_LEVEL",
           expansion="",
           )
-        add_error("FA2_WRONG_MAX_CHECKPOINTS",
+        tzip16_error("FA2_WRONG_MAX_CHECKPOINTS",
           expansion="",
           )
-        add_error("FA_NOT_PROPOSED_ADMIN",
+        tzip16_error("FA_NOT_PROPOSED_ADMIN",
           expansion="",
           )
 

--- a/python/teia_sc/__init__.py
+++ b/python/teia_sc/__init__.py
@@ -1,0 +1,2 @@
+ # package teia-sc
+#import error_collection

--- a/python/teia_sc/__init__.py
+++ b/python/teia_sc/__init__.py
@@ -1,2 +1,1 @@
- # package teia-sc
-#import error_collection
+# package teia-sc

--- a/python/teia_sc/error_collection.py
+++ b/python/teia_sc/error_collection.py
@@ -1,0 +1,145 @@
+"""A helper module to manage tezos smart contract errors for TZIP-16 metadata.
+"""
+
+from collections import defaultdict
+from sys import stdout
+from copy import copy
+from html import escape
+
+# TODO's :
+#  add support for multiple languages in errors
+
+# The follwing stores information collected on the various contracts
+contracts = defaultdict(lambda:defaultdict(lambda:defaultdict(dict)))
+
+ALLOWED_ERROR_DATA_KEYS = [
+    'failwith_type',  # Return type from `FAILWITH` instruction. Always represented as string.
+    'expansion',      # For TZIP-16 expansion metadata
+    'expansion_type', # For TZIP-16 expansion metadata
+    'doc',            # For extended documentation/tips for dealing with some errors. Optional.
+    ]
+
+ALLOWED_ERROR_MESSAGE_TYPES = [
+    'string', # 
+    'bytes',  # "0xfedcba9876543210" TODO untested
+    ]
+
+_TestError_default_flags = dict(
+    WARN_LONG_KEY = True,
+    LONG_KEY_THRESHOLD = 8,
+    ERROR_NO_MESSAGE = True,
+    WARN_NO_DOC = False,
+    )
+
+class SimpleTestMessageCollector():
+    # Simple class to collect and sort verification messages
+    def __init__(self):
+        self.warnings = []
+        self.errors = []
+        self.infos = []
+    def append(self, severity, message):
+        if severity=='INFO':
+            self.infos.append(message)
+        if severity=='WARN':
+            self.warnings.append(message)
+        if severity=='ERROR':
+            self.errors.append(message)
+    def to_dict(self):        
+        "Return instance variables as dict"
+        return { 'infos':self.infos, 'warnings':self.warnings, 'errors':self.errors, }
+
+class ErrorCollection():
+    "For collecting contract error messages, to provide them for metadata and documentation."
+
+    def __init__(self, contract_name) -> None:
+        self.contract = contracts[contract_name]
+        self.error_collection = self.contract['error_messages']
+        self.flags = _TestError_default_flags
+
+    def add_error(self, error_code, **kwargs) -> str:
+        "Add error and check input, possible kwargs in ALLOWED_ERROR_DATA_KEYS"
+        errors = self.error_collection
+        error = errors[error_code]
+        # Check for redefinitions and disallow changes in this method:
+        for key, item in kwargs.items():
+            if (key in error) and (error[key]!=item):
+                raise AttributeError(f"Redefining '{key}' with new value is not allowed, use TODO to update")
+            if not key in ALLOWED_ERROR_DATA_KEYS:
+                raise AttributeError(f"'{key}' is not in the allowed error keys: {ALLOWED_ERROR_DATA_KEYS}")
+            if key=='failwith_type' and item not in ALLOWED_ERROR_MESSAGE_TYPES:
+                raise AttributeError(f"'{key}' is not in the allowed error types: {ALLOWED_ERROR_MESSAGE_TYPES}")
+        # Put stuff into error
+        error.update(kwargs)
+
+    def verify_error_collection(self, **kwargs) -> SimpleTestMessageCollector:
+        "Verifies that all errors pass a set of tests."
+        # The optional parameters flags dict can be used to adjust flags by caller.
+        test_params = _TestError_default_flags.copy()
+        if 'flags' in kwargs:
+            test_params.update(kwargs['flags'])
+
+        # Tests on error data, to go through:
+        all_tests = dict(
+            LONG_CODE        = 'WARN',
+            NO_MESSAGE       = 'ERROR',
+            NO_MESSAGE_TYPE  = 'WARN',
+            NO_FAILWITH_TYPE = 'ERROR',
+            )
+
+        # Somewhere to collect messages:
+        messages = SimpleTestMessageCollector()
+        
+        # Iterate over the errors
+        for error_key, error_item in self.error_collection.items():
+            for test, severity in all_tests.items():
+                if test=='LONG_CODE':
+                    if len(error_key)>test_params['LONG_KEY_THRESHOLD']:
+                        messages.append(severity, f"Error code \"{error_key}\" longer than {test_params['LONG_KEY_THRESHOLD']} characters.")
+                if test=='NO_MESSAGE':
+                    if 'expansion' not in error_item or not error_item['expansion']:
+                        messages.append(severity, f"Error {error_key} 'expansion' attribute is not present or empty.")
+                if test=='NO_MESSAGE_TYPE':
+                    if 'expansion_type' not in error_item:
+                        messages.append(severity, f"Error {error_key} 'expansion_type' attribute is not present or empty.")
+                if test=='NO_FAILWITH_TYPE':
+                    if 'failwith_type' not in error_item:
+                        messages.append(severity, f"Error {error_key} 'failwith_type' attribute is not present or empty.")
+
+        return messages
+    
+    def tzip16_metadata(self):
+        "Return a list with error code and expansion, suitable for adding to the metadata. (Follows TZIP-16)"
+        def tzip16_error(code, failwith_type, expansion, expansion_type):
+            return dict(
+                error     = {failwith_type: code},   # Content should be a Michelson expression (TZIP-16), TODO add test?
+                expansion = {expansion_type: expansion}, # Content should be a Michelson expression (TZIP-16), TODO add test?
+                languages = ["en"],
+                )
+        for key, item in self.error_collection.items():
+            if not all(['failwith_type' in item, 'expansion' in item, 'expansion_type' in item]):
+                print(f"{key} : {item}")
+                raise AttributeError(f"All attributes ('failwith_type', 'expansion', 'expansion_type') required for TZIP-16 metadata in error \"{key}\"")
+
+        return [tzip16_error(key,item['failwith_type'],item['expansion'],item['expansion_type']) for key, item in self.error_collection.items()]
+
+    def scenario_linting_report(self, scenario):
+        "Output a SmartPy test report."
+        results = self.verify_error_collection()
+        scenario.h2("FAILWITH Linting report.")
+        if results.errors:
+            scenario.h3(f"Errors ({len(results.errors)})")
+            scenario.p("<br>".join([escape(str(e)) for e in results.errors]))
+        if results.warnings:
+            scenario.h3(f"Warnings ({len(results.warnings)})")
+            scenario.p("<br>".join([escape(str(e)) for e in results.warnings]))
+        if results.infos:
+            scenario.h3("Infos")
+            scenario.p("<br>".join([escape(str(e)) for e in results.infos]))
+
+        if results.errors or results.warnings:
+            print(f"Contract {len(results.errors)} linter errors and {len(results.warnings)} warnings.")
+
+    # Convenience aliases:
+    ERR=add_error
+
+

--- a/python/teia_sc/error_collection.py
+++ b/python/teia_sc/error_collection.py
@@ -1,25 +1,50 @@
+"""
+This module adds some tests and coverage for contract failwith results.
+
+This module will track failwith results that occur during testing. It will
+then check against errors explained in CONTRACT_METADATA_BASE['errors'] and
+report if some explanations/expansions are missing.
+
+The module will not discover contract failure conditions that do not occur
+during test. In some cases this could be hard cover. E.g. divide by zero, or
+other illegal use of instructions will also cause contract failure.
+
+Finding and testing these illegal conditions have not been a focus of this
+implementation yet, although it could perhaps be added soon. The expected
+use-case for the module as is, is to check all messages have explainers.
+"""
+
 from __future__ import annotations
 from collections import defaultdict
+from itertools import combinations
 from html import escape
-from json import dumps
 from re import match
 from inspect import stack
+from logging import warning
+from pprint import pformat
 
 # TODO's :
-#  Add support for multiple languages in errors.
+#  Add support for multiple languages.
 #  Look at Michelson return types in TZIP-16 standard,
 #    - How to specify properly
-#    - How to leverage smartpy for the return values
+#    - Leverage smartpy for the return values?
 
-# The follwing stores information collected on the various contracts
+# The following stores information collected on the various contracts
 contracts = defaultdict(lambda:defaultdict(lambda:defaultdict(dict)))
 
 # Keyword arguments that can be supplied to ErrorCollector.add_tzip16_error():
 ALLOWED_ERROR_DATA_KEYS = [
     'failwith_type',  # Return type from `FAILWITH` instruction. Always represented as string.
-    'expansion',      # Required for TZIP-16 expansion metadata
+    'expansion_data', # Required for TZIP-16 expansion metadata
     'expansion_type', # Required for TZIP-16 expansion metadata
-    'doc',            # For extended documentation/tips for dealing with some errors. Optional.
+    'languages',      # List of language codes, e.g. ["en", "fr"]
+    ]
+
+ALLOWED_ERROR_METADATA_KEYS = [
+    'error',     # Return type from `FAILWITH` instruction. Always represented as string.
+    'view',      # Required for TZIP-16 expansion metadata
+    'expansion', # Required for TZIP-16 expansion metadata
+    'languages', # List of language codes, e.g. ["en", "fr"]
     ]
 
 # Allowed values for failwith_type and expansion_type.
@@ -27,6 +52,22 @@ ALLOWED_ERROR_MESSAGE_TYPES = [
     'string',
     'bytes',
     ]
+
+# Language codes extracted from https://en.wikipedia.org/wiki/IETF_language_tag
+ALLOWED_LANGUAGE_CODES = {
+    'af', 'am',  'ar',  'arn', 'as',  'az',  'ba',  'be',  'bg',  'bn',  'bo',  'br',
+    'bs', 'ca',  'co',  'cs',  'cy',  'da',  'de',  'dsb', 'dv',  'el',  'en',  'es',
+    'et', 'eu',  'fa',  'fi',  'fil', 'fo',  'fr',  'fy',  'ga',  'gd',  'gl',  'gsw',
+    'gu', 'ha',  'he',  'hi',  'hr',  'hsb', 'hu',  'hy',  'id',  'ig',  'ii',  'is',
+    'it', 'iu',  'ja',  'ka',  'kk',  'kl',  'km',  'kn',  'ko',  'kok', 'ky',  'lb',
+    'lo', 'lt',  'lv',  'mi',  'mk',  'ml',  'mn',  'moh', 'mr',  'ms',  'mt',  'my',
+    'nb', 'ne',  'nl',  'nn',  'no',  'nso', 'oc',  'or',  'pa',  'pl',  'prs', 'ps',
+    'pt', 'qut', 'quz', 'rm',  'ro',  'ru',  'rw',  'sa',  'sah', 'se',  'si',  'sk',
+    'sl', 'sma', 'smj', 'smn', 'sms', 'sq',  'sr',  'sv',  'sw',  'syr', 'ta',  'te',
+    'tg', 'th',  'tk',  'tn',  'tr',  'tt',  'tzm', 'ug',  'uk',  'ur',  'uz',  'vi',
+    'wo', 'xh',  'yo',  'zh',  'zu'}
+
+MICHELSON_CORE_PRIMITIVE_TYPES = { "string", "int", "nat", "bytes" }
 
 # Module option to block smartpy injection. This will cause there to be no
 # discovery of smart contract errors (through tests). It may be useful as a
@@ -42,6 +83,57 @@ _TestError_default_flags = dict(
     ERROR_NO_MESSAGE = True,
     WARN_NO_DOC = False,
     )
+
+def check_legal_language_codes(tzip16_languages) -> True:
+    "Check that the languages given are a list with legal codes"
+    if not isinstance(tzip16_languages,list):
+        raise TypeError("TZIP-16 error languages should be given as a list of strings.")
+    for l_code in tzip16_languages: # pylint: disable=invalid-name
+        if not isinstance(l_code,str):
+            raise TypeError("TZIP-16 error languages should be given as a list of strings.")
+        if l_code not in ALLOWED_LANGUAGE_CODES:
+            raise ValueError(f"Unknown language code used for TZIP-16 error: \"{l_code}\"")
+    return True
+
+def check_expansion_legal(tzip16_expansion) -> True:
+    "Check that the expansion given is a dict with 1 item"
+    if not isinstance(tzip16_expansion,dict):
+        raise TypeError(f"TZIP-16 expansion should be a dict, not {type(tzip16_expansion)}.")
+    if not len(tzip16_expansion)==1:
+        raise TypeError('TZIP-16 static error expansion metadata expects 1 element')
+    # TODO more tests for expansion type and data can be added here
+    return True
+
+def check_error_legal(tzip16_error) -> True:
+    "Check that the error given is a dict with 1 item"
+    if not isinstance(tzip16_error,dict):
+        raise TypeError(f"TZIP-16 expansion should be a dict, not {type(tzip16_error)}.")
+    if not len(tzip16_error)==1:
+        raise TypeError("TZIP-16 static errors represent 1 stack element with a generic type."+
+                        " The metadata input should be a dict with 2 element.")
+    # TODO more tests for error type and data can be added here
+    return True
+
+def check_error_metadata_keys_clean(tzip16_error, critical=False) -> bool:
+    "Check remaining kwargs to warn about unknown key names, but otherwise pass them through"
+    clean = True
+    for key in tzip16_error.keys():
+        if key not in ALLOWED_ERROR_METADATA_KEYS:
+            msg = f"Unknown key '{key}' used for TZIP-16 error."
+            if not critical:
+                warning("Warning:" + msg)
+            else:
+                raise ValueError(msg)
+            clean = False
+    return clean
+
+def check_tzip16_error_kwargs(**kwargs) -> None:
+    "Check if arguments are allowed."
+    for key, item in kwargs.items():
+        if not key in ALLOWED_ERROR_DATA_KEYS:
+            raise AttributeError(f"'{key}' is not in the allowed error keys: {ALLOWED_ERROR_DATA_KEYS}")
+        if key=='failwith_type' and item not in ALLOWED_ERROR_MESSAGE_TYPES:
+            raise AttributeError(f"'{item}' is not in the allowed error types: {ALLOWED_ERROR_MESSAGE_TYPES}")
 
 class SimpleTestMessageCollector():
     "Simple class to collect and sort verification messages according to severity"
@@ -63,26 +155,24 @@ class SimpleTestMessageCollector():
         "Return dict with infos, warnings, messages."
         return { 'infos':self.infos, 'warnings':self.warnings, 'errors':self.errors, }
 
-def _add_sc_error_ref(error_code):
+def _add_sc_error_ref(failwith_result):
     "Marks presence of error"
     # These are false positives:
-    if match(r"View \w+ is invalid!", error_code):
+    if match(r"View \w+ is invalid!", failwith_result):
         return
     def get_contract_caller():
         # Traverse stack to check who the caller was
         for line in stack():
             if 'self' in line[0].f_locals:
-                cn = line[0].f_locals['self'].__class__.__name__
-                global contracts
-                if cn in contracts:
-                    return cn
+                contract_name = line[0].f_locals['self'].__class__.__name__
+                if contract_name in contracts:
+                    return contract_name
         return None, None
     contract_name = get_contract_caller()
     if contract_name:
         # Record the reference
-        global contracts
-        contracts[contract_name]['error_collection'][error_code].update({})
-    return error_code
+        contracts[contract_name]['error_collection'][failwith_result].update({})
+    return failwith_result
 
 class ErrorCollection():
     "For collecting contract error messages, to provide them for metadata and documentation."
@@ -92,55 +182,63 @@ class ErrorCollection():
     # Whether to add "ERROR_MISSING_*" strings for missing metadata fields.
     # This is currently required to avoid runtime errors.
     TZIP16_POPULATE_MISSING_KEYS = True
-    SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS = True
-    SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS_STDOUT = True
+    SCENARIO_LINTING_REPORT_PROVIDE_ERRORS_DICT = True
+    SCENARIO_LINTING_REPORT_PROVIDE_ERRORS_DICT_STDOUT = True
 
     def __init__(self, contract_name) -> None:
-        global contracts
         self.contract = contracts[contract_name]
         self.contract_name = contract_name
         self.error_collection = self.contract['error_collection']
+        self.languages = self.contract['languages'] = defaultdict(set)
         self.flags = _TestError_default_flags.copy()
         self.add_tzip16_error_default_kwargs = {}
 
-    def inject_into_smartpy(self, sp) -> ErrorCollection:
+    def add_base_metadata(self, cls) -> ErrorCollection:
+        """Add metadata from the cls class variable CONTRACT_METADATA_BASE
+        into the ErrorCollection instance."""
+        for error in cls.CONTRACT_METADATA_BASE['errors']:
+            self.add_tzip16_error_from_metadata(error)
+        # Return self for use with instantiation / chaining
+        return self
+
+    def inject_into_smartpy(self, smartpy) -> ErrorCollection:
         """Adds wrappers into SmartPy functions to gather contract failure messages.
 
-        :param sp: The smartpy module to inject into.
-        :type sp: module
+        :param smartpy: The smartpy module to inject into.
+        :type smartpy: module
         """
         # Wrapped functions have exact arguments replicated to hopefully
         # cause errors if smartpy changes the interface at some point.
-        if 'injected_error_collection' in dir(sp):
+        if 'injected_error_collection' in dir(smartpy):
             return self
         if BLOCK_SMARTPY_INJECTION:
             return self
-        # Wrap messages in sp.verify using ready-made functionality
-        sp.wrap_verify_messages = _add_sc_error_ref
-        # Wrap sp.failwith
+        # Wrap messages in smartpy.verify using ready-made functionality
+        smartpy.wrap_verify_messages = _add_sc_error_ref
+        # Wrap smartpy.failwith
         def wrapped_failwith(failwith):
             def failwith_wrapper(message):
                 _add_sc_error_ref(message)
                 return failwith(message)
             return failwith_wrapper
-        sp.failwith = wrapped_failwith(sp.failwith)
-        # Wrap sp.Expr.open_variant()
+        smartpy.failwith = wrapped_failwith(smartpy.failwith)
+        # Wrap smartpy.Expr.open_variant()
         def wrapped_open_variant(open_variant):
             def open_variant_wrapper(_self, name, message = None):
                 if message is not None:
                     _add_sc_error_ref(message)
                 return open_variant(_self, name, message=message)
             return open_variant_wrapper
-        sp.Expr.open_variant = wrapped_open_variant(sp.Expr.open_variant)
+        smartpy.Expr.open_variant = wrapped_open_variant(smartpy.Expr.open_variant)
         # Set flag so we don't repeat this procedure:
-        sp.injected_error_collection = True
-        # Return self for use with instantiation
+        smartpy.injected_error_collection = True
+        # Return self for use with instantiation / chaining
         return self
 
-    def add_error(self, error_code, **kwargs) -> None:
+    def add_error(self, failwith_result, **kwargs) -> None:
         "Add error"
         errors = self.error_collection
-        error = errors[error_code]
+        error = errors[failwith_result]
         if 'allow_updates' not in kwargs or not kwargs['allow_updates']:
             # Check for redefinitions and disallow changes in this method:
             kwargs.pop('allow_updates')
@@ -150,38 +248,30 @@ class ErrorCollection():
         # Put stuff into error
         error.update(kwargs)
 
-    def add_or_update_error(self, error_code, **kwargs) -> None:
+    def add_or_update_error(self, failwith_result, **kwargs) -> None:
         "Add or update error"
-        self.error_collection[error_code].update(kwargs)
-
-    def tzip16_error_check_kwargs(self, **kwargs) -> None:
-        "Check if arguments are allowed."
-        for key, item in kwargs.items():
-            if not key in ALLOWED_ERROR_DATA_KEYS:
-                raise AttributeError(f"'{key}' is not in the allowed error keys: {ALLOWED_ERROR_DATA_KEYS}")
-            if key=='failwith_type' and item not in ALLOWED_ERROR_MESSAGE_TYPES:
-                raise AttributeError(f"'{item}' is not in the allowed error types: {ALLOWED_ERROR_MESSAGE_TYPES}")
+        self.error_collection[failwith_result].update(kwargs)
 
     def tzip16_error_default(self, **kwargs) -> None:
         """Reset and set default arguments to add_tzip16_error() as given by kwargs.
 
-        This is a convenience method which gives less clutter when using add_tzip16_error to 
+        This is a convenience method which gives less clutter when using add_tzip16_error to
         input errors in the contract script.
         """
         # Check kwargs are allowed
-        self.tzip16_error_check_kwargs(**kwargs)
+        check_tzip16_error_kwargs(**kwargs)
         # Set the new default parameters for add_tzip16_error()
         self.add_tzip16_error_default_kwargs = dict(kwargs)
 
-    def add_tzip16_error(self, error_code, **kwargs) -> None:
+    def add_tzip16_error(self, failwith_result, **kwargs) -> None:
         "Add error with metadata to collection and check input. Allowed kwargs in ALLOWED_ERROR_DATA_KEYS."
         # Check kwargs are allowed
-        self.tzip16_error_check_kwargs(**kwargs)
+        check_tzip16_error_kwargs(**kwargs)
         # Start with current default parameters and update them with kwargs
         effective_kwargs = dict(self.add_tzip16_error_default_kwargs)
         effective_kwargs.update(kwargs)
         errors = self.error_collection
-        error = errors[error_code]
+        error = errors[failwith_result]
         # Check for redefinitions and disallow changes in this method:
         for key, item in effective_kwargs.items():
             if (key in error) and (error[key]!=item):
@@ -189,76 +279,147 @@ class ErrorCollection():
         # Put stuff into error
         error.update(effective_kwargs)
 
+
+    def add_languages(self, languages, failwith_result):
+        "Add the languages and the failwith_result to self.languages to keep track."
+        check_legal_language_codes(languages)
+        for l_code in languages:
+            self.languages[l_code].add(failwith_result)
+
+    def add_tzip16_error_from_metadata(self, tzip16_error):
+        """Reads a TZIP-16 error (defined as a dict in the contract metadata)
+        test if the input format looks compliant and inserts the error in
+        the ErrorCollection via add_tzip16_error()"""
+        # pylint: disable=too-many-branches
+        if 'view' in tzip16_error:
+            warning("NotImplementedWarning: TZIP-16 dynamic errors are not handled yet.")
+            return
+
+        check_error_legal(tzip16_error['error'])
+        # Get 'error' key, value pair.
+        (failwith_type, failwith_result), = tzip16_error['error'].items()
+        tzip16_error.pop('error')
+
+        # Start assembling a kwargs dict to pass to add_tzip16_error()
+        add_error_kwargs = dict(failwith_type=failwith_type)
+
+        if 'expansion' in tzip16_error:
+            check_expansion_legal(tzip16_error['expansion'])
+            # Get the key, value pair
+            (expansion_type, expansion_data), = tzip16_error['expansion'].items()
+            add_error_kwargs.update(expansion_type=expansion_type, expansion_data=expansion_data)
+            tzip16_error.pop('expansion')
+
+        # Pass through remaining kwargs (after pop)
+        add_error_kwargs.update(tzip16_error)
+
+        # Check remaining kwargs to warn about unknown key names
+        check_error_metadata_keys_clean(tzip16_error)
+
+        if 'languages' in tzip16_error:
+            self.add_languages(tzip16_error['languages'], failwith_result)
+
+        # Add the error into the internal structure
+        self.add_tzip16_error( failwith_result, **add_error_kwargs )
+
     def verify_error_collection(self, **kwargs) -> SimpleTestMessageCollector:
         "Verifies that all errors pass a set of tests."
+        # pylint: disable=too-many-branches
         # The optional parameters flags dict can be used to adjust flags by caller.
         test_params = self.flags.copy()
         if 'flags' in kwargs:
             test_params.update(kwargs['flags'])
 
         # Tests on error data, to go through:
-        all_tests = dict(
+        error_tests = dict(
             LONG_CODE         = 'WARN',
-            NO_EXPANSION      = 'ERROR',
+            NO_EXPANSION_DATA = 'ERROR',
             NO_EXPANSION_TYPE = 'ERROR',
             NO_FAILWITH_TYPE  = 'ERROR',
+            SIMPLE_FAILWITH_TYPE  = 'WARN',
             )
+
+        language_tests = dict(
+            LANGUAGES_HAVE_DIFFERENT_ERROR_RESULTS = 'WARN',
+        )
 
         # Somewhere to collect messages:
         messages = SimpleTestMessageCollector()
 
         # Iterate over the errors
         for error_key, error_item in self.error_collection.items():
-            for test, severity in all_tests.items():
+            for test, severity in error_tests.items():
                 if test=='LONG_CODE':
-                    if len(error_key)>test_params['LONG_KEY_THRESHOLD']:
-                        messages.append(severity, f"Error code \"{error_key}\" longer than {test_params['LONG_KEY_THRESHOLD']} characters.")
-                if test=='NO_EXPANSION':
-                    if 'expansion' not in error_item or not error_item['expansion']:
-                        messages.append(severity, f"Error {error_key} 'expansion' attribute is not present or empty.")
+                    if 'failwith_type' in error_item and error_item['failwith_type'] in MICHELSON_CORE_PRIMITIVE_TYPES:
+                        if len(error_key)>test_params['LONG_KEY_THRESHOLD']:
+                            messages.append(severity,
+                                f"Error result \"{error_key}\" longer than {test_params['LONG_KEY_THRESHOLD']} characters.")
+
+                if test=='NO_EXPANSION_DATA':
+                    if 'expansion_data' not in error_item or not error_item['expansion_data']:
+                        messages.append(severity, f"Error {error_key} 'expansion_data' attribute is not present or empty.")
                 if test=='NO_EXPANSION_TYPE':
                     if 'expansion_type' not in error_item:
                         messages.append(severity, f"Error {error_key} 'expansion_type' attribute is not present or empty.")
                 if test=='NO_FAILWITH_TYPE':
                     if 'failwith_type' not in error_item:
                         messages.append(severity, f"Error {error_key} 'failwith_type' attribute is not present or empty.")
+                if test=='SIMPLE_FAILWITH_TYPE':
+                    if ('failwith_type' in error_item
+                      and not error_item['failwith_type'] in MICHELSON_CORE_PRIMITIVE_TYPES):
+                        messages.append(severity, f"Non primitive return-type for error result \"{error_key}\".")
+
+        # Iterate over language combinations:
+        known_language_codes = set(self.languages.keys())
+        if 'LANGUAGES_HAVE_DIFFERENT_ERROR_RESULTS' in language_tests:
+            severity = language_tests['LANGUAGES_HAVE_DIFFERENT_ERROR_RESULTS']
+            for l1_code, l2_code in combinations(known_language_codes, 2):
+                l1_code_set, l2_code_set = self.languages[l1_code], self.languages[l2_code]
+                if l1_code_set.difference(l2_code_set):
+                    messages.append(severity, f"Language \"{l1_code}\" implements but \"{l2_code}\" does not implement:\n"
+                                            + f"{pformat(l1_code_set.difference(l2_code_set),indent=1,width=100)}")
+                if l2_code_set.difference(l1_code_set):
+                    messages.append(severity, f"Language \"{l2_code}\" implements but \"{l1_code}\" does not implement:\n"
+                                            + f"{pformat(l2_code_set.difference(l1_code_set),indent=1,width=100)}")
 
         return messages
 
     def tzip16_metadata(self, populate_missing_keys = True ) -> list(dict):
-        "Return a list with error code and expansion, suitable for adding to the metadata. (Follows TZIP-16)"
-        def tzip16_error(code, failwith_type, expansion, expansion_type):
+        "Return a list with error and expansion, suitable for adding to the metadata. (Follows TZIP-16)"
+        def tzip16_error(failwith_result, failwith_type, expansion_data, expansion_type):
             return dict(
-                error     = {failwith_type: code},       # Content should be a Michelson expression (TZIP-16), TODO investigate
-                expansion = {expansion_type: expansion}, # Content should be a Michelson expression (TZIP-16), TODO investigate
+                error     = {failwith_type: failwith_result},
+                expansion = {expansion_type: expansion_data},
                 languages = ["en"],
                 )
         for key, item in self.error_collection.items():
-            if not all(['failwith_type' in item, 'expansion' in item, 'expansion_type' in item]):
-                message = f"All attributes ('failwith_type', 'expansion', 'expansion_type') required for TZIP-16 metadata in error \"{key}\""
+            if not all(['failwith_type' in item, 'expansion_data' in item, 'expansion_type' in item]):
+                message = ("All attributes ('failwith_type', 'expansion_data',"
+                         +f" 'expansion_type') required for TZIP-16 metadata in error \"{key}\"")
                 print(f"TZIP-16 Non-compliance in {key} : {item}\n{message}")
                 if ErrorCollection.TZIP16_NONCOMPLIANCE_RAISE_ERROR:
                     raise AttributeError(message)
             if populate_missing_keys and ErrorCollection.TZIP16_POPULATE_MISSING_KEYS:
                 if not 'failwith_type' in item:
-                    item['failwith_type'] = 'ERROR_MISSING_TYPE'
-                if not 'expansion' in item:
-                    item['expansion'] = 'ERROR_MISSING_EXPANSION'
+                    item['failwith_type'] = 'ERROR_MISSING_FAILWITH_TYPE'
+                if not 'expansion_data' in item:
+                    item['expansion_data'] = 'ERROR_MISSING_EXPANSION_DATA'
                 if not 'expansion_type' in item:
                     item['expansion_type'] = 'ERROR_MISSING_EXPANSION_TYPE'
             else:
                 if not 'failwith_type' in item:
                     item['failwith_type'] = ''
-                if not 'expansion' in item:
-                    item['expansion'] = ''
+                if not 'expansion_data' in item:
+                    item['expansion_data'] = ''
                 if not 'expansion_type' in item:
                     item['expansion_type'] = ''
 
-        return [tzip16_error(key,item['failwith_type'],item['expansion'],item['expansion_type']) for key, item in self.error_collection.items()]
+        return [ tzip16_error(key,item['failwith_type'],item['expansion_data'],item['expansion_type'])
+                 for key, item in self.error_collection.items() ]
 
     def scenario_linting_report(self, scenario) -> None:
         "Output a SmartPy test report."
-        if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS_STDOUT:
+        if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ERRORS_DICT_STDOUT:
             sprint = lambda x: [scenario.p("<pre><code>"+x+"</code></pre>"), print(x)]
         else:
             sprint = lambda x: scenario.p("<pre><code>"+x+"</code></pre>")
@@ -266,33 +427,21 @@ class ErrorCollection():
         scenario.h2(f"FAILWITH Linting report for {self.contract_name}.")
         if results.errors:
             scenario.h3(f"Errors ({len(results.errors)})")
-            scenario.p("<br>".join([escape(str(e)) for e in results.errors]))
+            scenario.p("<br>".join([escape(str(error)) for error in results.errors]))
         if results.warnings:
             scenario.h3(f"Warnings ({len(results.warnings)})")
-            scenario.p("<br>".join([escape(str(e)) for e in results.warnings]))
+            scenario.p("<br>".join([escape(str(error)) for error in results.warnings]))
         if results.infos:
             scenario.h3("Infos")
-            scenario.p("<br>".join([escape(str(e)) for e in results.infos]))
+            scenario.p("<br>".join([escape(str(error)) for error in results.infos]))
 
-        tzip_dict = self.tzip16_metadata()
+        tzip_metadata_errors_list = self.tzip16_metadata()
         if results.errors or results.warnings:
-            print("*** TZIP-16 Metadata linting report for contract call errors.")
+            print("\n*** TZIP-16 Metadata linting report for contract call errors.")
             print(f"*** {self.contract_name}: {len(results.errors)} errors and {len(results.warnings)} warnings.")
 
-            if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS:
-                scenario.h3(msg:="*** Helpful snippet to add error metadata to contract:")
-                if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS_STDOUT:
+            if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ERRORS_DICT:
+                scenario.h3(msg:="Error metadata helper dict (contains errors or missing fields)")
+                if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ERRORS_DICT_STDOUT:
                     print(msg)
-                sprint(f"## The following lines would be added in {self.contract_name} class:\n"
-                   "# A function handle to call the contract's error_collection.add_tzip16_error()\n"
-                 + f"tzip16_error = {self.contract_name}.error_collection.add_tzip16_error\n\n"
-                 + f"## The following lines would be added in {self.contract_name}.__init__():\n"
-                 + "# A tzip16_error() call for each error encountered in the contract:\n"
-                 + "\n".join( [f"tzip16_error(\"{key}\","
-                     +"\n  " +"\n  ".join(
-                         [f"{item_key:18} = \"{item_value}\"," for item_key, item_value in item.items()]) + ")"
-                     for key, item in self.error_collection.items()]))
-
-        scenario.h3("JSON for error metadata")
-        scenario.p("<pre><code>"+dumps(tzip_dict, indent = 2)+"</pre></code>")
-
+                sprint(pformat({'errors':tzip_metadata_errors_list}, indent=1, width=100 ) )

--- a/python/teia_sc/error_collection.py
+++ b/python/teia_sc/error_collection.py
@@ -28,6 +28,13 @@ ALLOWED_ERROR_MESSAGE_TYPES = [
     'bytes',
     ]
 
+# Module option to block smartpy injection. This will cause there to be no
+# discovery of smart contract errors (through tests). It may be useful as a
+# switch to turn off that function without touching the contract code.
+# Not so useful today, but perhaps in the future if ever the case arises
+# where the injection has an undesirable effect on smartpy.
+BLOCK_SMARTPY_INJECTION = False
+
 # Default settings for
 _TestError_default_flags = dict(
     WARN_LONG_KEY = True,
@@ -104,6 +111,8 @@ class ErrorCollection():
         # Wrapped functions have exact arguments replicated to hopefully
         # cause errors if smartpy changes the interface at some point.
         if 'injected_error_collection' in dir(sp):
+            return self
+        if BLOCK_SMARTPY_INJECTION:
             return self
         # Wrap messages in sp.verify using ready-made functionality
         sp.wrap_verify_messages = _add_sc_error_ref

--- a/python/teia_sc/error_collection.py
+++ b/python/teia_sc/error_collection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from collections import defaultdict
 from html import escape
+from json import dumps
 from re import match
 from inspect import stack
 
@@ -244,10 +245,10 @@ class ErrorCollection():
             scenario.h3("Infos")
             scenario.p("<br>".join([escape(str(e)) for e in results.infos]))
 
+        tzip_dict = self.tzip16_metadata()
         if results.errors or results.warnings:
             print("*** TZIP-16 Metadata linting report for contract call errors.")
             print(f"*** {self.contract_name}: {len(results.errors)} errors and {len(results.warnings)} warnings.")
-            _ = self.tzip16_metadata()
 
             if ErrorCollection.SCENARIO_LINTING_REPORT_PROVIDE_ADDERROR_CALLS:
                 scenario.h3(msg:="*** Helpful snippet to add error metadata to contract:")
@@ -262,3 +263,7 @@ class ErrorCollection():
                      +"\n  " +"\n  ".join(
                          [f"{item_key:18} = \"{item_value}\"," for item_key, item_value in item.items()]) + ")"
                      for key, item in self.error_collection.items()]))
+
+        scenario.h3("JSON for error metadata")
+        scenario.p("<pre><code>"+dumps(tzip_dict, indent = 2)+"</pre></code>")
+

--- a/python/tests/daoGovernance_test.py
+++ b/python/tests/daoGovernance_test.py
@@ -1256,7 +1256,6 @@ def test_quadratic_voting():
     scenario.verify(dao.data.token_votes[(0, user4.address)].vote.is_variant("yes"))
     scenario.verify(dao.data.token_votes[(0, user4.address)].weight == 100 * int(pow(400 * decimals / 10000, 0.5)))
     scenario.verify(dao.data.token_votes[(0, user5.address)].vote.is_variant("no"))
-    scenario.verify(dao.data.token_votes[(0, user5.address)].weight == int(pow(5 * 100, 0.5)))
     scenario.verify(dao.data.token_votes[(0, user5.address)].weight == 100 * int(pow(5 * decimals / 10000, 0.5)))
 
 @sp.add_test(name="Lint FAILWITH messages")

--- a/python/tests/daoGovernance_test.py
+++ b/python/tests/daoGovernance_test.py
@@ -1256,3 +1256,9 @@ def test_quadratic_voting():
     scenario.verify(dao.data.token_votes[(0, user4.address)].weight == int(pow(400 * 100, 0.5)))
     scenario.verify(dao.data.token_votes[(0, user5.address)].vote.is_variant("no"))
     scenario.verify(dao.data.token_votes[(0, user5.address)].weight == int(pow(5 * 100, 0.5)))
+
+@sp.add_test(name="Lint FAILWITH messages")
+def test_error_message_rules():
+    scenario = sp.test_scenario()
+    daoGovernanceModule.DAOGovernance.error_collection.scenario_linting_report(scenario)
+

--- a/python/tests/daoToken_test.py
+++ b/python/tests/daoToken_test.py
@@ -3,7 +3,7 @@
 """
 
 import smartpy as sp
-
+from os import environ
 # Import the DAO token FA2 contract module
 daoTokenModule = sp.io.import_script_from_url("file:contracts/daoToken.py")
 
@@ -906,7 +906,9 @@ def test_add_max_share_exception():
     fa2.add_max_share_exception(user1.address).run(valid=False, sender=user2)
 
 
-@sp.add_test(name="Lint FAILWITH messages")
-def test_error_message_rules():
-    scenario = sp.test_scenario()
-    daoTokenModule.DAOToken.error_collection.scenario_linting_report(scenario)
+if ('tzip16_error_lint' in environ.get('TEIA_SC_PARAMS','').split(':') and
+    type(daoTokenModule.DAOToken.error_collection).__name__ == 'ErrorCollection'):
+    @sp.add_test(name="Lint FAILWITH messages")
+    def test_error_message_rules():
+        scenario = sp.test_scenario()
+        daoTokenModule.DAOToken.error_collection.scenario_linting_report(scenario)

--- a/python/tests/daoToken_test.py
+++ b/python/tests/daoToken_test.py
@@ -904,3 +904,9 @@ def test_add_max_share_exception():
 
     # Check that only the admin can add exceptions
     fa2.add_max_share_exception(user1.address).run(valid=False, sender=user2)
+
+
+@sp.add_test(name="Lint FAILWITH messages")
+def test_error_message_rules():
+    scenario = sp.test_scenario()
+    daoTokenModule.DAOToken.error_collection.scenario_linting_report(scenario)


### PR DESCRIPTION
This commit adds a `teia_sc.error_collection` module which allows an option
to collect error metadata. The main use is to encapsulate tests and
methods related to producing consistent and compliant TZIP-16 error
metadata.

The first commit implements an example in daoToken only:
```
TARGET=daoToken make test
```
Results in `output/tests/daoToken/Lint_FAILWITH_messages/log.html`,
and in contract metadata under "errors", e.g. see Metdata tab in `output/tests/daoToken/Test_set_metadata/log.html`

The code has not been linted yet, but might be ok to take a look at now, at a high level. 