### PR TITLE
Add contract_metadata setup to daoGovernance

### DIFF
--- a/python/contracts/daoToken.py
+++ b/python/contracts/daoToken.py
@@ -149,10 +149,14 @@ class DAOToken(sp.Contract):
             proposed_administrator=sp.none)
 
         # Build the TZIP-016 contract metadata
-        # This is helpful to get the off-chain views code in json format
+        # (For producing metadata JSON and TZIP-16 linting)
         self.contract_metadata = dict(DAOToken.CONTRACT_METADATA_BASE)
         self.contract_metadata.update({
-            "views": [
+            "views": [ 
+                # NOTE: TZIP-16 specifies views as a list of offchain views, so perhaps 
+                # adding "onchain" : "true" seems reasonable. The structure is however
+                # not built until the init_metadata call. So it would perhaps be better 
+                # to ask smartpy if they can add it. 
                 self.get_balance,
                 self.total_supply,
                 self.all_tokens,

--- a/python/tests/daoGovernance_test.py
+++ b/python/tests/daoGovernance_test.py
@@ -1,7 +1,7 @@
 """Unit tests for the DAO governance class.
 
 """
-
+from os import environ
 import smartpy as sp
 
 # Import the DAO modules
@@ -1270,7 +1270,9 @@ def test_quadratic_voting():
     scenario.verify(dao.data.token_votes[(0, user5.address)].vote.is_variant("no"))
     scenario.verify(dao.data.token_votes[(0, user5.address)].weight == 100 * int(pow(5 * decimals / 10000, 0.5)))
 
-@sp.add_test(name="Lint FAILWITH messages")
-def test_error_message_rules():
-    scenario = sp.test_scenario()
-    daoGovernanceModule.DAOGovernance.error_collection.scenario_linting_report(scenario)
+if ('tzip16_error_lint' in environ.get('TEIA_SC_PARAMS','').split(':') and
+    type(daoGovernanceModule.DAOGovernance.error_collection).__name__ == 'ErrorCollection'):
+    @sp.add_test(name="Lint FAILWITH messages")
+    def test_error_message_rules():
+        scenario = sp.test_scenario()
+        daoGovernanceModule.DAOGovernance.error_collection.scenario_linting_report(scenario)


### PR DESCRIPTION
Just a commit that should have gone into PR #11. 

The tool is usable and I think working more on this isn't very productive anymore. However it's possible to add some base and error metadata to all contracts. The main caveat is that only one language is possible at this time. This can be added offline, or one can turn off the environment variables to allow everything to pass through.