### PR TITLE
Teia wiki contract

### DIFF
--- a/metadata/channels.json
+++ b/metadata/channels.json
@@ -1,0 +1,188 @@
+{
+    "name": "Teia Channels",
+    "description": "On-chain community channel contract with three-tier access control (creator > admin > merkle user), hide/delete separation, edit history, per-channel and contract-wide ban lists, and multisig super moderation. Channel creators choose between three access modes: unrestricted (anyone can post), allowlist (Merkle-proof-gated posting), or closed (creator and admins only — used for artist blogs and DMs). Messages carry a hidden flag and version counter; each edit archives the prior version into an on-chain history big_map. Delete is sender-only regardless of access mode, preventing retroactive delete-power changes on mode transitions. Three moderation tiers: senders hide their own messages, channel creators/admins moderate their channel, and any multisig user can hide any message in any channel as super moderator. Per-action fees (post, edit, hide) plus a channel creation fee, all governable via the Teia multisig. Includes per-channel admin sets (capped at 15), per-channel ban list, contract-wide ban list, and reply threading with parent-hidden checks.",
+    "version": "1.0.0",
+    "license": {
+        "name": "MIT",
+        "details": "The MIT License"
+    },
+    "authors": ["Teia Community <https://twitter.com/TeiaCommunity>"],
+    "homepage": "https://teia.art",
+    "source": {
+        "tools": ["SmartPy"],
+        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/messages/channels.py"
+    },
+    "interfaces": ["TZIP-016"],
+    "errors": [
+        {
+            "error": { "string": "CONTRACT_PAUSED" },
+            "expansion": { "string": "The contract is currently paused" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "TEZ_TRANSFER" },
+            "expansion": { "string": "The operation does not accept tez transfers" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INCORRECT_FEE" },
+            "expansion": { "string": "The provided tez amount does not match the required fee for this action (post_fee for post_message, edit_fee for edit_message, hide_fee for set_own_message_hidden, channel_fee for create_channel)" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNEL_NOT_FOUND" },
+            "expansion": { "string": "The given channel ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNEL_HIDDEN" },
+            "expansion": { "string": "The channel has been hidden and does not accept new messages or configuration changes" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_METADATA" },
+            "expansion": { "string": "The metadata URI cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_CONTENT" },
+            "expansion": { "string": "The message content cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CONTENT_TOO_LARGE" },
+            "expansion": { "string": "The message content exceeds the maximum size of 32768 bytes" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_NOT_FOUND" },
+            "expansion": { "string": "The parent message does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_WRONG_CHANNEL" },
+            "expansion": { "string": "The parent message belongs to a different channel" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_HIDDEN" },
+            "expansion": { "string": "The parent message has been hidden and cannot receive new replies" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "MESSAGE_NOT_FOUND" },
+            "expansion": { "string": "The given message ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "UNDERFLOW" },
+            "expansion": { "string": "Deleting this message would cause the channel message count to underflow" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_AUTHORIZED" },
+            "expansion": { "string": "The caller is not authorized to perform this action" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_CHANNEL_CREATOR" },
+            "expansion": { "string": "Only the channel creator can perform this operation (closed channels restrict configure_channel to creator only)" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_CHANNEL_ADMIN" },
+            "expansion": { "string": "Only the channel creator or a channel admin can perform this operation" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "TOO_MANY_ADMINS" },
+            "expansion": { "string": "A channel cannot have more than 15 admins" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "USER_BANNED" },
+            "expansion": { "string": "The caller is on the contract-wide ban list and cannot post or edit messages" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "USER_BANNED_IN_CHANNEL" },
+            "expansion": { "string": "The caller is banned from this specific channel and cannot post new messages (channel creators are exempt from per-channel bans)" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CANNOT_BAN_CREATOR" },
+            "expansion": { "string": "The channel creator cannot be banned from their own channel" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "VERSION_NOT_FOUND" },
+            "expansion": { "string": "The requested historical version of the message does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "ALLOWLIST_NEEDS_ROOT" },
+            "expansion": { "string": "Allowlist access mode requires a Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "ROOT_NOT_ALLOWED" },
+            "expansion": { "string": "Only allowlist access mode may set a Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NO_MERKLE_ROOT" },
+            "expansion": { "string": "The channel is in allowlist mode but has no Merkle root set" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PROOF_REQUIRED" },
+            "expansion": { "string": "A Merkle proof is required to post to an allowlist-restricted channel" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INVALID_MERKLE_PROOF" },
+            "expansion": { "string": "The provided Merkle proof does not verify against the channel's Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the is_user view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NOT_MULTISIG_USER" },
+            "expansion": { "string": "The operation can only be executed by one of the linked multisig wallet users" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_GET_MIN_VOTES_FAILED" },
+            "expansion": { "string": "Failed to call the get_minimum_votes view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_GET_EXPIRATION_FAILED" },
+            "expansion": { "string": "Failed to call the get_expiration_time view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_PROPOSAL_EXPIRED" },
+            "expansion": { "string": "The proposal has expired and can no longer be executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NO_PROPOSAL" },
+            "expansion": { "string": "The given proposal ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_ALREADY_EXECUTED" },
+            "expansion": { "string": "The proposal has already been executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NOT_ENOUGH_VOTES" },
+            "expansion": { "string": "The proposal did not receive enough positive votes to be executed" },
+            "languages": ["en"]
+        }
+    ]
+}

--- a/metadata/messagesChannels.json
+++ b/metadata/messagesChannels.json
@@ -1,0 +1,163 @@
+{
+    "name": "Teia Channels",
+    "description": "On-chain community channel contract with three-tier access control. Channel creators can delegate admin rights and choose between three access modes: unrestricted (anyone can post), allowlist (Merkle-proof-gated posting), or closed (creator and admins only). Includes per-channel admin sets (capped at 15), reply threading, soft-delete via hidden flag, and multisig governance for pausing, fee management, fee recipient, and contract metadata updates.",
+    "version": "1.0.0",
+    "license": {
+        "name": "MIT",
+        "details": "The MIT License"
+    },
+    "authors": ["Teia Community <https://twitter.com/TeiaCommunity>"],
+    "homepage": "https://teia.art",
+    "source": {
+        "tools": ["SmartPy"],
+        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/messages/channels.py"
+    },
+    "interfaces": ["TZIP-016"],
+    "errors": [
+        {
+            "error": { "string": "CONTRACT_PAUSED" },
+            "expansion": { "string": "The contract is currently paused" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "TEZ_TRANSFER" },
+            "expansion": { "string": "The operation does not accept tez transfers" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INCORRECT_FEE" },
+            "expansion": { "string": "The provided tez amount does not match the required fee" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNEL_NOT_FOUND" },
+            "expansion": { "string": "The given channel ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNEL_HIDDEN" },
+            "expansion": { "string": "The channel has been hidden and does not accept new messages or configuration changes" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_METADATA" },
+            "expansion": { "string": "The metadata URI cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_CONTENT" },
+            "expansion": { "string": "The message content cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CONTENT_TOO_LARGE" },
+            "expansion": { "string": "The message content exceeds the maximum size of 32768 bytes" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_NOT_FOUND" },
+            "expansion": { "string": "The parent message does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_WRONG_CHANNEL" },
+            "expansion": { "string": "The parent message belongs to a different channel" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "MESSAGE_NOT_FOUND" },
+            "expansion": { "string": "The given message ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "UNDERFLOW" },
+            "expansion": { "string": "Deleting this message would cause the channel message count to underflow" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_AUTHORIZED" },
+            "expansion": { "string": "The caller is not authorized to perform this action" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_CHANNEL_CREATOR" },
+            "expansion": { "string": "Only the channel creator can perform this operation" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_CHANNEL_ADMIN" },
+            "expansion": { "string": "Only the channel creator or a channel admin can perform this operation" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "TOO_MANY_ADMINS" },
+            "expansion": { "string": "A channel cannot have more than 15 admins" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "ALLOWLIST_NEEDS_ROOT" },
+            "expansion": { "string": "Allowlist access mode requires a Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "ROOT_NOT_ALLOWED" },
+            "expansion": { "string": "Only allowlist access mode may set a Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NO_MERKLE_ROOT" },
+            "expansion": { "string": "The channel is in allowlist mode but has no Merkle root set" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PROOF_REQUIRED" },
+            "expansion": { "string": "A Merkle proof is required to post to an allowlist-restricted channel" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INVALID_MERKLE_PROOF" },
+            "expansion": { "string": "The provided Merkle proof does not verify against the channel's Merkle root" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the is_user view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NOT_MULTISIG_USER" },
+            "expansion": { "string": "The operation can only be executed by one of the linked multisig wallet users" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_GET_MIN_VOTES_FAILED" },
+            "expansion": { "string": "Failed to call the get_minimum_votes view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_GET_EXPIRATION_FAILED" },
+            "expansion": { "string": "Failed to call the get_expiration_time view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_PROPOSAL_EXPIRED" },
+            "expansion": { "string": "The proposal has expired and can no longer be executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NO_PROPOSAL" },
+            "expansion": { "string": "The given proposal ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_ALREADY_EXECUTED" },
+            "expansion": { "string": "The proposal has already been executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CHANNELS_NOT_ENOUGH_VOTES" },
+            "expansion": { "string": "The proposal did not receive enough positive votes to be executed" },
+            "languages": ["en"]
+        }
+    ]
+}

--- a/metadata/pollComments.json
+++ b/metadata/pollComments.json
@@ -1,0 +1,148 @@
+{
+    "name": "Teia Poll Comments",
+    "description": "On-chain comments on off-chain teia.art polls, gated by Teia FA2 token ownership. Any token holder can post and reply to comments; senders can edit and hide their own comments; any single multisig user can hide or unhide any comment for fast moderation; banning a wallet from posting requires a passed multisig proposal. Includes reply threading via parent_id, a contract-wide ban list, and multisig governance for pause, fees, fee recipient, token gate configuration, and contract metadata updates.",
+    "version": "1.0.0",
+    "license": {
+        "name": "MIT",
+        "details": "The MIT License"
+    },
+    "authors": ["Teia Community <https://twitter.com/TeiaCommunity>"],
+    "homepage": "https://teia.art",
+    "source": {
+        "tools": ["SmartPy"],
+        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/messages/poll_comments.py"
+    },
+    "interfaces": ["TZIP-016"],
+    "errors": [
+        {
+            "error": { "string": "CONTRACT_PAUSED" },
+            "expansion": { "string": "The contract is currently paused" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "TEZ_TRANSFER" },
+            "expansion": { "string": "The operation does not accept tez transfers" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INCORRECT_FEE" },
+            "expansion": { "string": "The provided tez amount does not match the required fee" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_CONTENT" },
+            "expansion": { "string": "The comment content cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "CONTENT_TOO_LARGE" },
+            "expansion": { "string": "The comment content exceeds the maximum size of 32768 bytes" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_NOT_FOUND" },
+            "expansion": { "string": "The parent comment does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_WRONG_POLL" },
+            "expansion": { "string": "The parent comment belongs to a different poll" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PARENT_HIDDEN" },
+            "expansion": { "string": "The parent comment has been hidden and cannot receive new replies" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "COMMENT_NOT_FOUND" },
+            "expansion": { "string": "The given comment ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_AUTHORIZED" },
+            "expansion": { "string": "The caller is not authorized to perform this action" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "USER_BANNED" },
+            "expansion": { "string": "The caller is on the ban list and cannot post or edit comments" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "PENDING_POST_EXISTS" },
+            "expansion": { "string": "Another comment is already being processed; please retry once the prior post resolves" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NO_PENDING_POST" },
+            "expansion": { "string": "The balance callback was invoked but no pending comment is in flight" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INVALID_CALLBACK_SENDER" },
+            "expansion": { "string": "The balance callback can only be invoked by the configured Teia FA2 contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "EMPTY_BALANCE_RESPONSE" },
+            "expansion": { "string": "The FA2 contract returned an empty balance response" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "NOT_TOKEN_HOLDER" },
+            "expansion": { "string": "The caller does not hold the configured Teia token and cannot post comments" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "SELF_CALLBACK_ERROR" },
+            "expansion": { "string": "Could not resolve the balance_callback entrypoint on the contract itself" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "INVALID_FA2" },
+            "expansion": { "string": "The configured FA2 contract does not expose a compatible balance_of entrypoint" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the is_user view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_NOT_MULTISIG_USER" },
+            "expansion": { "string": "The operation can only be executed by one of the linked multisig wallet users" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_GET_MIN_VOTES_FAILED" },
+            "expansion": { "string": "Failed to call the get_minimum_votes view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_GET_EXPIRATION_FAILED" },
+            "expansion": { "string": "Failed to call the get_expiration_time view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_PROPOSAL_EXPIRED" },
+            "expansion": { "string": "The proposal has expired and can no longer be executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_NO_PROPOSAL" },
+            "expansion": { "string": "The given proposal ID does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_ALREADY_EXECUTED" },
+            "expansion": { "string": "The proposal has already been executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "POLL_NOT_ENOUGH_VOTES" },
+            "expansion": { "string": "The proposal did not receive enough positive votes to be executed" },
+            "languages": ["en"]
+        }
+    ]
+}

--- a/metadata/tokenComments.json
+++ b/metadata/tokenComments.json
@@ -1,7 +1,7 @@
 {
-    "name": "Teia Poll Comments",
-    "description": "On-chain comments on off-chain teia.art polls, gated by Teia FA2 token ownership. Any token holder can post and reply to comments; senders can edit and hide their own comments. Each of the three sender-facing actions (post, edit, hide) charges its own configurable fee, sent to the fee recipient (typically the Teia multisig); any fee can be set to 0 via governance. Every edit archives the prior version into an on-chain history big_map so the full edit history of any comment is preserved forever and queryable via the get_comment_version view. Any single multisig user can hide or unhide any comment for fast moderation (no fee, no vote); banning a wallet from posting requires a passed multisig proposal. Includes reply threading via parent_id, a contract-wide ban list, and multisig governance for pause, fees (per action), fee recipient, token gate configuration, and contract metadata updates.",
-    "version": "1.2.0",
+    "name": "Teia Token Comments",
+    "description": "On-chain comments on Teia FA2 tokens, gated by ownership of the specific token being commented on. Each post specifies a target (fa2_address, token_id); the caller must hold that token at post time. Any token holder can post and reply to comments on tokens they hold; senders can edit and hide their own comments. Each of the three sender-facing actions (post, edit, hide) charges its own configurable fee, sent to the fee recipient (typically the Teia multisig); any fee can be set to 0 via governance. Every edit archives the prior version into an on-chain history big_map so the full edit history of any comment is preserved forever and queryable via the get_comment_version view. Any single multisig user can hide or unhide any comment for fast moderation (no fee, no vote); banning a wallet from posting requires a passed multisig proposal. Includes reply threading via parent_id (replies must target the same (fa2_address, token_id) as the parent), a contract-wide ban list, and multisig governance for pause, fees (per action), fee recipient, and contract metadata updates.",
+    "version": "1.0.0",
     "license": {
         "name": "MIT",
         "details": "The MIT License"
@@ -10,7 +10,7 @@
     "homepage": "https://teia.art",
     "source": {
         "tools": ["SmartPy"],
-        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/messages/poll_comments.py"
+        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/messages/token_comments.py"
     },
     "interfaces": ["TZIP-016"],
     "errors": [
@@ -45,8 +45,8 @@
             "languages": ["en"]
         },
         {
-            "error": { "string": "PARENT_WRONG_POLL" },
-            "expansion": { "string": "The parent comment belongs to a different poll" },
+            "error": { "string": "PARENT_WRONG_TOKEN" },
+            "expansion": { "string": "The parent comment belongs to a different token (fa2_address or token_id mismatch); a reply must target the same (fa2_address, token_id) as its parent" },
             "languages": ["en"]
         },
         {
@@ -86,7 +86,7 @@
         },
         {
             "error": { "string": "INVALID_CALLBACK_SENDER" },
-            "expansion": { "string": "The balance callback can only be invoked by the configured Teia FA2 contract" },
+            "expansion": { "string": "The balance callback can only be invoked by the FA2 contract targeted by the pending post_comment call" },
             "languages": ["en"]
         },
         {
@@ -96,7 +96,7 @@
         },
         {
             "error": { "string": "NOT_TOKEN_HOLDER" },
-            "expansion": { "string": "The caller does not hold the configured Teia token and cannot post comments" },
+            "expansion": { "string": "The caller does not hold the targeted token and cannot post a comment on it" },
             "languages": ["en"]
         },
         {
@@ -106,46 +106,46 @@
         },
         {
             "error": { "string": "INVALID_FA2" },
-            "expansion": { "string": "The configured FA2 contract does not expose a compatible balance_of entrypoint" },
+            "expansion": { "string": "The targeted FA2 contract does not expose a compatible balance_of entrypoint" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_VIEW_FAILED" },
+            "error": { "string": "TC_VIEW_FAILED" },
             "expansion": { "string": "Failed to call the is_user view on the linked multisig contract" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_NOT_MULTISIG_USER" },
+            "error": { "string": "TC_NOT_MULTISIG_USER" },
             "expansion": { "string": "The operation can only be executed by one of the linked multisig wallet users" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_GET_MIN_VOTES_FAILED" },
+            "error": { "string": "TC_GET_MIN_VOTES_FAILED" },
             "expansion": { "string": "Failed to call the get_minimum_votes view on the linked multisig contract" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_GET_EXPIRATION_FAILED" },
+            "error": { "string": "TC_GET_EXPIRATION_FAILED" },
             "expansion": { "string": "Failed to call the get_expiration_time view on the linked multisig contract" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_PROPOSAL_EXPIRED" },
+            "error": { "string": "TC_PROPOSAL_EXPIRED" },
             "expansion": { "string": "The proposal has expired and can no longer be executed" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_NO_PROPOSAL" },
+            "error": { "string": "TC_NO_PROPOSAL" },
             "expansion": { "string": "The given proposal ID does not exist" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_ALREADY_EXECUTED" },
+            "error": { "string": "TC_ALREADY_EXECUTED" },
             "expansion": { "string": "The proposal has already been executed" },
             "languages": ["en"]
         },
         {
-            "error": { "string": "POLL_NOT_ENOUGH_VOTES" },
+            "error": { "string": "TC_NOT_ENOUGH_VOTES" },
             "expansion": { "string": "The proposal did not receive enough positive votes to be executed" },
             "languages": ["en"]
         }

--- a/metadata/wiki.json
+++ b/metadata/wiki.json
@@ -1,0 +1,113 @@
+{
+    "name": "Teia Wiki Contract",
+    "description": "On-chain registry for the Teia community wiki. Each page is identified by an auto-incrementing integer page_id and stores its current IPFS/Arweave CID, a hidden flag and a full, append-only version history (every version keeps its CID, editor, optional proposer and timestamp, queryable via the get_version view). Page names/titles live off-chain in the page's CID content; duplicate-name checks are handled by the UI. Moderators and linked multisig users can create, update and hide pages directly. Teia token holders can submit proposals to edit an existing page (create_proposal) or to create a brand new page (prop_new_page); each proposal action charges its own configurable fee, forwarded to the fee recipient (typically the Teia multisig), and any fee can be set to 0 via governance. A moderator or multisig user approves or rejects pending proposals; a single approval applies the change (creating the page or appending a new version). Multisig governance covers pause, the linked multisig/moderator/token addresses, the token id, per-action fees, the fee recipient and contract metadata updates; governance proposals require a minimum number of votes and expire after a configurable time, both fetched from the linked multisig contract.",
+    "version": "2.0.0",
+    "license": {
+        "name": "MIT",
+        "details": "The MIT License"
+    },
+    "authors": ["Teia Community <https://twitter.com/TeiaCommunity>"],
+    "homepage": "https://teia.art",
+    "source": {
+        "tools": ["SmartPy"],
+        "location": "https://github.com/teia-community/teia-smart-contracts/blob/main/python/contracts/wiki/wiki.py"
+    },
+    "interfaces": ["TZIP-016"],
+    "errors": [
+        {
+            "error": { "string": "WIKI_NOT_AUTHORIZED" },
+            "expansion": { "string": "The caller is not authorized to perform this action" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_PAUSED" },
+            "expansion": { "string": "The contract is currently paused" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_TEZ_TRANSFER" },
+            "expansion": { "string": "The operation does not accept tez transfers" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_INCORRECT_FEE" },
+            "expansion": { "string": "The provided tez amount does not match the required fee for this action (propose_edit_fee for create_proposal, propose_page_fee for prop_new_page)" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_EMPTY_CID" },
+            "expansion": { "string": "The CID cannot be empty" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_PAGE_NOT_FOUND" },
+            "expansion": { "string": "No page exists for the given page id" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_VERSION_NOT_FOUND" },
+            "expansion": { "string": "No version exists for the given (page id, version) key" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_NO_TOKENS" },
+            "expansion": { "string": "The caller does not hold any Teia tokens and cannot submit a proposal" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_NO_PROPOSAL" },
+            "expansion": { "string": "The given community proposal id does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_ALREADY_RESOLVED" },
+            "expansion": { "string": "The community proposal has already been approved or rejected" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_NO_GOV_PROPOSAL" },
+            "expansion": { "string": "The given governance proposal id does not exist" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_GOV_ALREADY_EXECUTED" },
+            "expansion": { "string": "The governance proposal has already been executed and cannot be voted on or executed again" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_GOV_NOT_ENOUGH_VOTES" },
+            "expansion": { "string": "The governance proposal did not receive enough positive votes to be executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_GOV_EXPIRED" },
+            "expansion": { "string": "The governance proposal has expired and can no longer be voted on or executed" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_MULTISIG_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the is_user view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_MODERATOR_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the is_moderator view on the linked moderator contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_TOKEN_VIEW_FAILED" },
+            "expansion": { "string": "Failed to call the get_balance view on the linked Teia token contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_GET_MIN_VOTES_FAILED" },
+            "expansion": { "string": "Failed to call the get_minimum_votes view on the linked multisig contract" },
+            "languages": ["en"]
+        },
+        {
+            "error": { "string": "WIKI_GET_EXPIRATION_FAILED" },
+            "expansion": { "string": "Failed to call the get_expiration_time view on the linked multisig contract" },
+            "languages": ["en"]
+        }
+    ]
+}

--- a/python/contracts/messages/README.md
+++ b/python/contracts/messages/README.md
@@ -1,6 +1,6 @@
 # Teia Messaging Network Token
 
-Two smart contracts for on-chain messaging on Tezos. The Channels contract has its full reference inline below; Token Gated Chat has a brief summary (spec to follow).
+Three smart contracts for on-chain messaging on Tezos. Channels has a full reference inline below; Token Gated Chat has a brief summary; Poll Comments has a full reference further down.
 
 ## Contracts at a glance
 
@@ -18,7 +18,7 @@ Public or private community channels with three-tier access control.
 - Only the creator can add/remove admins or hide the channel (soft delete)
 - Message replies via `parent_id`
 
-Full reference: see [Channels v1, full reference](#channels-v1-full-reference) below.
+Full reference: see [Channels v1, full reference](#channels) below.
 
 ### 2. Token Gated Chat (`token_gate.py`)
 
@@ -31,27 +31,50 @@ Chat rooms for FA2 token holders.
 - Only the message sender can delete their own messages (moderation via multisig, maybe every multisig wallet can hide/delete messages and ban wallets)
 - Message replies via `parent_id`
 
+### 3. Poll Comments (`poll_comments.py`)
+
+Comments on off-chain teia.art polls, gated by Teia FA2 token ownership.
+
+- Anyone holding the configured Teia token (one FA2 contract + token_id, set in storage) can comment
+- Polls live off-chain (e.g. teia.art/poll/49); the contract only stores comments and references each poll by `poll_id`
+- Token check runs through FA2 `balance_of` callback, same flow as Token Gated Chat
+- Senders can **edit** their own comments and **hide** them; each action carries its own configurable fee (`post_fee`, `edit_fee`, `hide_fee`), any of which may be set to 0 via governance. Every edit archives the prior version into an on-chain history big_map (`comment_history`) so the full edit history of any comment is queryable forever via the `get_comment_version` view.
+- Moderation: any single multisig user can hide or un-hide any comment directly (no vote required, no fee) — fast take-down path
+- Multisig also maintains a contract-wide **ban list**; banned wallets can't `post_comment` or `edit_comment` on any poll. Banning still requires a passed multisig proposal (vote-gated)
+- Replies via `parent_id`; replies to hidden parents are rejected
+
+Full reference: see [Poll Comments, full reference](#poll-comments) below.
+
 ## Shared features
 
-Both contracts share:
+All three contracts share:
 
-- **Message fees**, configurable fee per message
+- **Message fees**, configurable fee per message (settable to 0 via governance)
 - **Multisig governance**, pause contract, change fees, update metadata
-- **Events**, all actions emit events with full data for frontend indexing
-- **Reply support**, messages can reference a parent message
+- **Events**, all state-changing actions emit typed events for indexing
+- **Reply support**, messages/comments can reference a parent
 
 ## Build & test
-
-Depends on your setup, more info soon.
-
 
 ```bash
 source smartpy-env/bin/activate
 python python/contracts/messages/channels.py
 python python/contracts/messages/token_gate.py
+python python/contracts/messages/poll_comments.py
 ```
 
-Compiled artifacts (Michelson + initial storage) land in the corresponding deploy folders next to the repo root.
+Compiled artifacts (Michelson + initial storage) land in the corresponding deploy folders next to the repo root. To force an output directory:
+
+```bash
+SMARTPY_OUTPUT_DIR=output/poll_comments python python/contracts/messages/poll_comments.py
+```
+
+## Deployments
+
+| Contract | Network | Address |
+|---|---|---|
+| Poll Comments | Mainnet | `KT1HjHTTVa7hc9C2NGQh6H3m2gNKRDZPtg86` |
+| Poll Comments | Shadownet | `KT1G7UK1hvM7yVbGoL6h8uKLmcYGNKGqas1j` |
 
 ---
 
@@ -274,3 +297,209 @@ Every state mutation emits a typed event, so events can be decoded directly from
 `channel_created`, `channel_configured`, `channel_updated`, `channel_admins_updated`, `channel_hidden`, `message_posted`, `message_deleted`.
 
 `update_channel_admins` and `delete_message` are the only mutations that don't include the resulting state, for the admin set you must replay all `channel_admins_updated` events; for a deleted message, `messages[id]` will be absent in storage.
+
+---
+
+# Poll Comments
+
+On-chain comments on off-chain teia.art polls, gated by ownership of the Teia FA2 token. Multisig governs moderation and parameter changes. Implemented in SmartPy at [`poll_comments.py`](./poll_comments.py).
+
+## Model
+
+- **Polls** are not stored on chain. The contract just records a `poll_id: nat` on each comment and trusts the off-chain poll system (teia.art) for the rest.
+- **Token gating** happens through the FA2 `balance_of` callback: when someone calls `post_comment`, the contract stores a `pending_comment`, asks the configured FA2 for the sender's balance of the configured `token_id`, and only writes the comment once the callback confirms balance > 0.
+- **Moderation** is one-flag (`hidden: bool`) on each comment. Three paths flip it: (a) the comment's sender via `set_own_comment_hidden`; (b) any multisig user via `moderate_comment_hidden` — no vote, just `is_user` check; (c) historically via proposal, but the `set_comment_hidden` action has been removed in favor of (b) for faster moderation. Hide is reversible from any of these paths. Nothing is ever hard-deleted.
+- **Editing** is allowed for the sender only. Each edit archives the *current* version into the `comment_history` big_map at key `(comment_id, version)` before overwriting `content` in place; the live `version` counter is then incremented and `timestamp` is reset to `sp.now`. The full prior version (poll_id, sender, content, parent_id, timestamp) is preserved on chain forever and queryable via the `get_comment_version` view.
+- **Ban list** is contract-wide (not per-poll). Multisig governance adds or removes addresses via the `set_user_banned` proposal action. A banned address is blocked from `post_comment` and `edit_comment` on every poll; it can still toggle `set_own_comment_hidden` on its existing comments.
+
+## Storage
+
+```
+multisig_address     : address                                # governance contract
+metadata             : big_map[string, bytes]                 # TZIP-16
+paused               : bool                                   # global pause flag (governance-set)
+fa2_address          : address                                # Teia token FA2 (governance-set)
+token_id             : nat                                    # Teia token id (governance-set)
+comments             : big_map[nat, comment]                  # flat comment store
+comment_history      : big_map[(nat, nat), history_entry]     # archived prior versions, keyed by (comment_id, version)
+banned               : big_map[address, unit]                 # contract-wide ban list (governance-set); presence = banned
+pending_comment      : option[pending_comment]                # populated during a balance_of round-trip
+comment_id_counter   : nat                                    # next comment_id (starts at 1)
+post_fee             : mutez                                  # required tez on post_comment (may be 0)
+edit_fee             : mutez                                  # required tez on edit_comment (may be 0)
+hide_fee             : mutez                                  # required tez on set_own_comment_hidden (may be 0)
+fee_recipient        : address
+proposals            : big_map[nat, proposal]                 # governance proposals
+votes                : big_map[(nat, address), bool]          # governance votes
+counter              : nat                                    # proposal counter
+```
+
+### `comment` record
+
+```
+poll_id     : nat                       # off-chain reference (e.g. teia.art/poll/49 → 49)
+sender      : address
+content     : bytes                     # ≤ 32768 bytes (32 KiB)
+parent_id   : option[nat]               # for threaded replies
+hidden      : bool                      # set by sender or multisig
+timestamp   : timestamp                 # when the *current* version became live (= post time at v1, reset to sp.now on each edit). Original post time is recoverable from `comment_history[(c, 1)].timestamp` once the comment has been edited at least once.
+version     : nat                       # current version index — starts at 1 on post, +1 per edit. Archived versions live at `comment_history[(comment_id, 1..version-1)]` (empty for never-edited comments at version=1).
+```
+
+### `history_entry` record
+
+```
+poll_id     : nat                       # always the same as the live comment's poll_id (comments can't be moved between polls)
+sender      : address                   # always the original sender (only the sender can edit)
+content     : bytes                     # the content as it was at this version
+parent_id   : option[nat]               # always the same as the live comment's parent_id (reparenting not supported)
+timestamp   : timestamp                 # the moment this version became live (i.e. when it was posted or when the preceding edit happened)
+```
+
+## Entrypoints
+
+### Comment ops
+
+#### `post_comment(poll_id, content, parent_id)`
+
+| | |
+|---|---|
+| Caller | anyone holding the configured Teia token at the configured `token_id`, not on the ban list |
+| Tez | exactly `post_fee` |
+| Behavior | stores `pending_comment` and calls FA2 `balance_of`; the comment is only written once `balance_callback` confirms a non-zero balance |
+| Validation | `1 ≤ len(content) ≤ 32768`; no other `pending_comment` in flight; if `parent_id` set, parent must exist, be on the same poll, and not be hidden |
+| Event | `comment_posted { poll_id, comment_id, sender, parent_id, timestamp }` (emitted from `balance_callback`; content is intentionally not in the event so that edit/hide are meaningful) |
+
+#### `balance_callback(responses)`
+
+Internal-facing — must be called by the configured FA2 contract as the response to `balance_of`. Writes the pending comment if a matching response shows balance > 0, sends the fee to `fee_recipient`, emits `comment_posted`, and clears `pending_comment`. Manual calls fail with `INVALID_CALLBACK_SENDER`.
+
+#### `edit_comment(comment_id, content)`
+
+| | |
+|---|---|
+| Caller | original sender only, not on the ban list |
+| Tez | exactly `edit_fee` (may be 0) |
+| Behavior | snapshots the current version (poll_id, sender, content, parent_id, timestamp) into `comment_history[(comment_id, version)]`, increments the live `version`, overwrites `content`, sets `timestamp = sp.now`. `parent_id` and `hidden` are unchanged. Forwards the fee to `fee_recipient`. |
+| Validation | `1 ≤ len(content) ≤ 32768` |
+| Event | `comment_edited { poll_id, comment_id, sender, parent_id, timestamp, version }` — `timestamp` is `sp.now` (the new live-since for this version); `version` is the new live version index; the just-archived snapshot is at `comment_history[(comment_id, version - 1)]` |
+| Storage burn | each edit allocates a new big_map entry sized by the *prior* content (~250 mutez/byte). For a small text comment that's a few hundred mutez; for a 32 KiB max comment it's ~8 tez. Storage burn is paid directly by the editor on top of `edit_fee`. |
+
+#### `set_own_comment_hidden(comment_id, hidden)`
+
+| | |
+|---|---|
+| Caller | original sender only |
+| Tez | exactly `hide_fee` (may be 0) |
+| Behavior | flips the `hidden` flag on caller's own comment; forwards the fee to `fee_recipient` |
+| Event | `comment_hidden_set { comment_id, hidden, updated_by }` |
+
+#### `moderate_comment_hidden(comment_id, hidden)`
+
+| | |
+|---|---|
+| Caller | any multisig user (checked via the multisig's `is_user` view); no vote required |
+| Tez | 0 |
+| Behavior | flips the `hidden` flag on any comment for fast moderation |
+| Validation | comment exists |
+| Event | `comment_moderated { comment_id, hidden, moderator }` |
+
+### Governance (multisig users only)
+
+The contract delegates user-management and quorum to the multisig at `multisig_address` via three views: `is_user`, `get_minimum_votes`, `get_expiration_time`.
+
+#### `submit_proposal(action)`
+
+`action` is a variant:
+
+| Tag | Payload | Effect on execute |
+|---|---|---|
+| `set_pause` | `bool` | sets global `paused` |
+| `set_post_fee` | `mutez` | updates `post_fee` |
+| `set_edit_fee` | `mutez` | updates `edit_fee` |
+| `set_hide_fee` | `mutez` | updates `hide_fee` |
+| `set_fee_recipient` | `address` | updates `fee_recipient` |
+| `update_multisig_address` | `address` | swaps the multisig governance contract |
+| `update_metadata` | `{key: string, value: bytes}` | writes to TZIP-16 metadata big_map |
+| `update_token_gate` | `{fa2_address: address, token_id: nat}` | swaps the FA2 contract + token id used for gating |
+| `set_user_banned` | `{address: address, banned: bool}` | adds or removes an address from the contract-wide ban list (banned addresses can't `post_comment` or `edit_comment`) |
+
+Note: hiding individual comments is **not** a proposal action — see `moderate_comment_hidden` above for the direct multisig-user path.
+
+#### `vote_proposal(proposal_id, approval)`
+
+Multisig users vote yes/no. Re-voting overwrites the previous vote (the prior tally is decremented before applying the new one).
+
+#### `execute_proposal(proposal_id)`
+
+Any multisig user. Requires `positive_votes ≥ get_minimum_votes()` from the multisig and the proposal not to be expired.
+
+## Views (on-chain)
+
+| View | Returns |
+|---|---|
+| `get_comment(comment_id: nat)` | `comment` record (live version) |
+| `get_comment_version((comment_id, version): (nat, nat))` | `history_entry` record (an archived prior version). Errors with `VERSION_NOT_FOUND` if the slot is empty. |
+| `get_comment_version_count(comment_id: nat)` | `nat` — total version count (= the live `version` field). Versions start at 1, so this returns 1 for a never-edited comment and `1 + number_of_edits` otherwise. Archived snapshots live at indices `1..count-1`; the live version (index = `count`) lives in `comments[comment_id]`. |
+| `get_fees()` | `{post_fee: mutez, edit_fee: mutez, hide_fee: mutez}` |
+| `get_token_gate()` | `{fa2_address: address, token_id: nat}` |
+| `get_proposal(proposal_id: nat)` | `proposal` record |
+| `get_vote((proposal_id, voter))` | `bool` (default false) |
+| `is_banned(address: address)` | `bool` (true if the address is on the ban list) |
+
+## Error codes
+
+See the module docstring at the top of [`poll_comments.py`](./poll_comments.py) for the full list, grouped by area:
+
+- comment ops (`CONTRACT_PAUSED`, `TEZ_TRANSFER`, `INCORRECT_FEE`, `EMPTY_CONTENT`, `CONTENT_TOO_LARGE`, `PARENT_NOT_FOUND`, `PARENT_WRONG_POLL`, `PARENT_HIDDEN`, `COMMENT_NOT_FOUND`, `NOT_AUTHORIZED`, `USER_BANNED`, `VERSION_NOT_FOUND`)
+- token gate / FA2 (`PENDING_POST_EXISTS`, `NO_PENDING_POST`, `INVALID_CALLBACK_SENDER`, `EMPTY_BALANCE_RESPONSE`, `NOT_TOKEN_HOLDER`, `SELF_CALLBACK_ERROR`, `INVALID_FA2`)
+- governance (`POLL_VIEW_FAILED`, `POLL_NOT_MULTISIG_USER`, `POLL_GET_MIN_VOTES_FAILED`, `POLL_GET_EXPIRATION_FAILED`, `POLL_PROPOSAL_EXPIRED`, `POLL_NO_PROPOSAL`, `POLL_ALREADY_EXECUTED`, `POLL_NOT_ENOUGH_VOTES`)
+
+## Indexer notes
+
+Event tags emitted by the contract:
+
+Comment lifecycle:
+- `comment_posted { poll_id, comment_id, sender, parent_id, timestamp }` — emitted from `balance_callback` after a successful post. New posts start at `version = 1`.
+- `comment_edited { poll_id, comment_id, sender, parent_id, timestamp, version }` — emitted after a successful edit. `timestamp` is the moment the new version became live (i.e. `sp.now` at edit time, matching the new value of `comments[comment_id].timestamp`). `version` is the new live version index; the previous version is now archived at `comment_history[(comment_id, version - 1)]`. Content lives in the `comments` / `comment_history` big_maps, not the event.
+- `comment_hidden_set { comment_id, hidden, updated_by }` — emitted by `set_own_comment_hidden`; `updated_by` is the comment's sender
+- `comment_moderated { comment_id, hidden, moderator }` — emitted by `moderate_comment_hidden`; `moderator` is the multisig user who flipped the flag
+
+Governance state changes emitted from `execute_proposal`:
+- `pause_set { proposal_id, paused, updated_by }`
+- `post_fee_set { proposal_id, post_fee, updated_by }`
+- `edit_fee_set { proposal_id, edit_fee, updated_by }`
+- `hide_fee_set { proposal_id, hide_fee, updated_by }`
+- `fee_recipient_set { proposal_id, fee_recipient, updated_by }`
+- `multisig_address_set { proposal_id, multisig_address, updated_by }`
+- `metadata_updated { proposal_id, key, updated_by }` — value lives in the `metadata` big_map
+- `token_gate_updated { proposal_id, fa2_address, token_id, updated_by }`
+- `user_banned_set { proposal_id, address, banned, updated_by }`
+
+`submit_proposal` and `vote_proposal` deliberately don't emit events — the `proposals` and `votes` big_maps are queryable via views and re-readable on every block. Subscribe to the per-action events above to react to executed proposals.
+
+Because `edit_comment` overwrites content in place and `comment_edited` carries no content, indexers must re-read the live comment from the `comments` big_map on edit events. The just-archived prior version is available at `comment_history[(comment_id, version - 1)]` where `version` is the new live version index emitted on the event. The full chain of versions can be reconstructed by walking indices `1..version-1` in `comment_history` plus the live `comments[comment_id]` entry. Versions start at 1.
+
+## Deployment
+
+The file ships with two scenarios, `poll_comments_deploy_shadownet` and `poll_comments_deploy_mainnet`. They differ only in the multisig/fee_recipient and Teia FA2 addresses.
+
+| Network | Multisig & fee_recipient | Teia FA2 | token_id | post_fee | edit_fee | hide_fee |
+|---|---|---|---|---|---|---|
+| Shadownet | `KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP` | `KT1RHCCYWKDwMzmTZq7kG7H3brHAno3yfMQD` | `0` | `25000` mutez | `25000` mutez | `25000` mutez |
+| Mainnet | `KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb` | `KT1QrtA753MSv8VGxkDrKKyJniG5JtuHHbtV` | `0` | `25000` mutez | `25000` mutez | `25000` mutez |
+
+To originate on Shadownet (assumes the compiled artifacts are in `output/poll_comments/poll_comments_deploy_shadownet/`):
+
+```bash
+STORAGE=$(cat output/poll_comments/poll_comments_deploy_shadownet/step_002_cont_0_storage.tz)
+octez-client --endpoint https://rpc.shadownet.teztnets.com \
+  originate contract poll_comments_v1 \
+  transferring 0 from WALLET \
+  running output/poll_comments/poll_comments_deploy_shadownet/step_002_cont_0_contract.tz \
+  --init "$STORAGE" --burn-cap 10
+```
+
+Current Mainnet deployment: `KT1HjHTTVa7hc9C2NGQh6H3m2gNKRDZPtg86` (alias `poll_comments_mainnet_v1`). Metadata pinned at `ipfs://QmXfrEZmN6spvdoqrHvF6ZfhTrL8zfCSJ5nhc2drrn6Rm8`.
+
+Current Shadownet deployment: `KT1G7UK1hvM7yVbGoL6h8uKLmcYGNKGqas1j` (alias `poll_comments_v3`; adds the direct-multisig-user moderation path via `moderate_comment_hidden`). Earlier shadownet deployments retained for reference: `KT1THhsqsBxRwy7LhrzNEuqYv1s171g3CcjJ` (v2, multisig-vote-only moderation), `KT1Fj15RVREYq8mvLgVpvoYM79cA2or9sPMp` (v1, pre-ban-list).

--- a/python/contracts/messages/README.md
+++ b/python/contracts/messages/README.md
@@ -1,0 +1,276 @@
+# Teia Messaging Network Token
+
+Two smart contracts for on-chain messaging on Tezos. The Channels contract has its full reference inline below; Token Gated Chat has a brief summary (spec to follow).
+
+## Contracts at a glance
+
+### 1. Channels (`channels.py`)
+
+Public or private community channels with three-tier access control.
+
+- Anyone can create a channel
+- Three access modes:
+  - **Unrestricted**, anyone can post
+  - **Allowlist**, only addresses with a valid Merkle proof against `merkle_root` (scales to thousands)
+  - **Closed**, only creator and admins; intended for DMs and small private rooms
+- Channel creator can add admins; admins can configure access, update metadata, and post freely
+- Message deletion: in `closed` channels, sender only; in `unrestricted`/`allowlist` channels, sender or creator
+- Only the creator can add/remove admins or hide the channel (soft delete)
+- Message replies via `parent_id`
+
+Full reference: see [Channels v1, full reference](#channels-v1-full-reference) below.
+
+### 2. Token Gated Chat (`token_gate.py`)
+
+Chat rooms for FA2 token holders.
+
+- Every token gets a chat room automatically (no need to create one)
+- Room key = FA2 contract address + token ID
+- To post, the contract checks if you hold the token via FA2 `balance_of` callback
+- Rooms are created on first message
+- Only the message sender can delete their own messages (moderation via multisig, maybe every multisig wallet can hide/delete messages and ban wallets)
+- Message replies via `parent_id`
+
+## Shared features
+
+Both contracts share:
+
+- **Message fees**, configurable fee per message
+- **Multisig governance**, pause contract, change fees, update metadata
+- **Events**, all actions emit events with full data for frontend indexing
+- **Reply support**, messages can reference a parent message
+
+## Build & test
+
+Depends on your setup, more info soon.
+
+
+```bash
+source smartpy-env/bin/activate
+python python/contracts/messages/channels.py
+python python/contracts/messages/token_gate.py
+```
+
+Compiled artifacts (Michelson + initial storage) land in the corresponding deploy folders next to the repo root.
+
+---
+
+# Channels
+
+On-chain community channels with three-tier access control and optional Merkle-tree allowlists. Implemented in SmartPy at [`channels.py`](./channels.py).
+
+## Access model
+
+Three roles, per channel:
+
+| Role | Set by | What they can do |
+|---|---|---|
+| **Creator** | whoever calls `create_channel` (immutable) | everything below + `update_channel_admins`, `hide_channel` |
+| **Admin** | creator, via `update_channel_admins` | `configure_channel`, `update_channel`, `delete_message`, post freely |
+| **User** (Merkle member) | proof against `merkle_root` set by creator/admin | post in allowlist channels |
+
+Three access modes:
+
+- `unrestricted`, anyone may post
+- `allowlist`, only creator, admins, or addresses with a valid Merkle proof against `channel.merkle_root`
+- `closed`, only creator and admins; no Merkle path. Intended for DMs and small private peer rooms
+
+`hide_channel` the channel record stays but `post_message` and `configure_channel` reject it.
+
+### Closed mode and DMs
+
+`closed` direct messages: a 2-person DM is created with `access_mode=closed`, no `merkle_root`, and the peer added as the single admin. Two semantics distinguish it from the others:
+
+- **Posting** is restricted to the privileged set (creator + admins). Non-privileged callers get `NOT_AUTHORIZED` with no Merkle path to override it.
+- **Deletion** is sender-only: the creator cannot delete an admin/peer's message in a closed channel. In `unrestricted` and `allowlist` channels, the creator retains delete power over any message (sender-or-creator rule).
+
+Switching modes is allowed in both directions. Switching out of `closed` (e.g., to `allowlist`) re-grants the creator delete power over any prior peer message, by design, but worth communicating to participants.
+
+## Storage
+
+```
+multisig_address     : address                                # governance contract
+metadata             : big_map[string, bytes]                 # TZIP-16
+paused               : bool                                   # global pause flag (governance-set)
+channels             : big_map[nat, channel]                  # channel records
+messages             : big_map[nat, message]                  # flat message store
+channel_admins       : big_map[nat, set[address]]             # per-channel admin set (≤ 15 admins per channel)
+channel_id_counter   : nat                                    # next channel_id (starts at 1)
+message_id_counter   : nat                                    # next message_id (starts at 1)
+message_fee          : mutez                                  # required tez on post_message
+channel_fee          : mutez                                  # required tez on create_channel
+fee_recipient        : address
+proposals            : big_map[nat, proposal]                 # governance proposals
+votes                : big_map[(nat, address), bool]          # governance votes
+counter              : nat                                    # proposal counter
+```
+
+### `channel` record
+
+```
+creator        : address
+metadata_uri   : bytes                  # e.g. IPFS
+access_mode    : variant(unrestricted | allowlist | closed)
+merkle_root    : option[bytes]          # required iff access_mode = allowlist
+merkle_uri     : option[bytes]          # off-chain pointer to the full address list
+message_count  : nat                    # incremented on post, decremented on delete
+hidden         : bool
+timestamp      : timestamp              # creation time
+```
+
+### `message` record
+
+```
+channel_id  : nat
+sender      : address
+content     : bytes                     # ≤ 32768 bytes (32 KiB)
+parent_id   : option[nat]               # for threaded replies
+timestamp   : timestamp
+```
+
+## Entrypoints
+
+### Channel ops
+
+#### `create_channel(metadata_uri, access_mode, merkle_root, merkle_uri, admins)`
+
+| | |
+|---|---|
+| Caller | anyone |
+| Tez | exactly `channel_fee` (or 0 if fee is 0) |
+| Behavior | spawns a new channel with sender as creator, full config applied at creation, optional initial admin set written into `channel_admins` |
+| Validation | `metadata_uri` non-empty; `access_mode = allowlist ⇔ merkle_root.is_some()` |
+| Notes | `admins` is `list[address]`; pass `[]` for none |
+| Event | `channel_created { channel_id, creator, metadata_uri, access_mode, merkle_root, merkle_uri, admins, timestamp }` |
+
+#### `configure_channel(channel_id, access_mode, merkle_root, merkle_uri)`
+
+| | |
+|---|---|
+| Caller | creator or admin |
+| Tez | 0 |
+| Behavior | updates the access mode, Merkle root and Merkle URI |
+| Restrictions | rejects if channel is hidden |
+| Event | `channel_configured { channel_id, access_mode, merkle_root, merkle_uri, configured_by }` |
+
+#### `update_channel(channel_id, metadata_uri)`
+
+| | |
+|---|---|
+| Caller | creator or admin |
+| Tez | 0 |
+| Behavior | replaces the channel `metadata_uri` |
+| Validation | `metadata_uri` non-empty |
+| Event | `channel_updated { channel_id, metadata_uri, updated_by }` |
+
+#### `update_channel_admins(channel_id, to_add, to_remove)`
+
+| | |
+|---|---|
+| Caller | creator only |
+| Tez | 0 |
+| Behavior | adds/removes addresses from the per-channel admin set |
+| Event | `channel_admins_updated { channel_id, to_add, to_remove }` |
+
+#### `hide_channel(channel_id)`
+
+| | |
+|---|---|
+| Caller | creator only |
+| Tez | 0 |
+| Behavior | sets `hidden = true`; the channel becomes read-only |
+| Event | `channel_hidden { channel_id, hidden_by }` |
+
+### Message ops
+
+#### `post_message(channel_id, content, proof, parent_id)`
+
+| | |
+|---|---|
+| Caller | creator, admin, or any address (subject to `access_mode`) |
+| Tez | exactly `message_fee` |
+| Behavior | appends a message; if `parent_id` is set it must point to a message in the same channel |
+| Access | unrestricted: anyone. allowlist: creator/admin bypass; everyone else must supply a valid `proof` against `channel.merkle_root`. closed: creator/admin only, all others rejected with `NOT_AUTHORIZED` |
+| Validation | `1 ≤ len(content) ≤ 32768`; channel exists and is not hidden |
+| Event | `message_posted { channel_id, message_id, sender, parent_id, timestamp }` (content is intentionally not emitted, read it from the `messages` big_map so `delete_message` actually deletes) |
+
+#### `delete_message(message_id)`
+
+| | |
+|---|---|
+| Caller | depends on the channel's `access_mode`: closed → message sender only; unrestricted/allowlist → message sender or channel creator |
+| Tez | 0 |
+| Behavior | deletes the message and decrements `channel.message_count` |
+| Event | `message_deleted { channel_id, message_id, deleted_by }` |
+
+### Governance (multisig users only)
+
+The contract delegates user-management and quorum to the multisig at `multisig_address` via three views: `is_user`, `get_minimum_votes`, `get_expiration_time`.
+
+#### `submit_proposal(action)`
+
+`action` is a variant:
+
+| Tag | Payload | Effect on execute |
+|---|---|---|
+| `set_pause` | `bool` | sets global `paused` |
+| `set_message_fee` | `mutez` | updates `message_fee` |
+| `set_channel_fee` | `mutez` | updates `channel_fee` |
+| `set_fee_recipient` | `address` | updates `fee_recipient` |
+| `update_multisig_address` | `address` | swaps the multisig governance contract |
+| `update_metadata` | `{key: string, value: bytes}` | writes to TZIP-16 metadata big_map |
+
+#### `vote_proposal(proposal_id, approval)`
+
+Multisig users vote yes/no. Re-voting overwrites the previous vote (the prior tally is decremented before applying the new one).
+
+#### `execute_proposal(proposal_id)`
+
+Any multisig user. Requires `positive_votes ≥ get_minimum_votes()` from the multisig and the proposal not to be expired.
+
+## Views (on-chain)
+
+| View | Returns |
+|---|---|
+| `get_channel(channel_id: nat)` | `channel` record |
+| `get_message(message_id: nat)` | `message` record |
+| `get_message_fee()` | `mutez` |
+| `get_channel_fee()` | `mutez` |
+| `is_channel_admin({channel_id, address})` | `bool` (true for creator or admin) |
+| `get_proposal(proposal_id: nat)` | `proposal` record |
+| `get_vote((proposal_id, voter))` | `bool` (default false) |
+
+## Building a Merkle proof (allowlist channels)
+
+The on-chain leaf format is **`blake2b(pack(address))`**, keyed only on the address (no per-channel salt, no namespace).
+
+Off-chain steps:
+
+1. Collect the list of allowed addresses, deduplicate, and sort (any deterministic order works as long as the tree is rebuilt the same way every time).
+2. Compute each leaf as `blake2b(pack(address))`. SmartPy's `pack` for an address produces the standard Michelson `0x05...` encoding, most Tezos client libraries expose this as `packAddress` or similar.
+3. Build a binary Merkle tree using `blake2b(left || right)` for internal nodes. Pair from the bottom up; if a level has an odd count, duplicate the last node (or use whichever convention you prefer, just be consistent).
+4. The **root** is the last remaining hash; store it on-chain via `merkle_root`. Publish the address list at `merkle_uri` (typically IPFS).
+5. To prove inclusion of an address, walk from its leaf to the root and emit one `merkle_step` per level:
+   - `direction = 0` if the **sibling** is on the **left** (so on-chain we compute `blake2b(sibling || computed)`)
+   - `direction = 1` if the **sibling** is on the **right** (`blake2b(computed || sibling)`)
+6. Submit `proof = [merkle_step, ...]` along with `post_message`.
+
+Smallest case: a single-address tree has `merkle_root = blake2b(pack(address))` and the proof is `Some([])`, empty list.
+
+
+## Error codes
+
+See the module docstring at the top of [`channels.py`](./channels.py) for the full list, grouped by area:
+
+- channel/message ops (`CONTRACT_PAUSED`, `INCORRECT_FEE`, `CHANNEL_NOT_FOUND`, `CHANNEL_HIDDEN`, `EMPTY_CONTENT`, `CONTENT_TOO_LARGE`, `PARENT_NOT_FOUND`, `PARENT_WRONG_CHANNEL`, `MESSAGE_NOT_FOUND`, `UNDERFLOW`, `EMPTY_METADATA`, `TEZ_TRANSFER`)
+- authorization (`NOT_AUTHORIZED`, `NOT_CHANNEL_CREATOR`, `NOT_CHANNEL_ADMIN`)
+- access config (`ALLOWLIST_NEEDS_ROOT`, `ROOT_NOT_ALLOWED`, `NO_MERKLE_ROOT`, `PROOF_REQUIRED`, `INVALID_MERKLE_PROOF`)
+- governance (`CHANNELS_VIEW_FAILED`, `CHANNELS_NOT_MULTISIG_USER`, `CHANNELS_GET_MIN_VOTES_FAILED`, `CHANNELS_GET_EXPIRATION_FAILED`, `CHANNELS_PROPOSAL_EXPIRED`, `CHANNELS_NO_PROPOSAL`, `CHANNELS_ALREADY_EXECUTED`, `CHANNELS_NOT_ENOUGH_VOTES`)
+
+## Indexer notes
+
+Every state mutation emits a typed event, so events can be decoded directly from contract type info. The full set of event tags:
+
+`channel_created`, `channel_configured`, `channel_updated`, `channel_admins_updated`, `channel_hidden`, `message_posted`, `message_deleted`.
+
+`update_channel_admins` and `delete_message` are the only mutations that don't include the resulting state, for the admin set you must replay all `channel_admins_updated` events; for a deleted message, `messages[id]` will be absent in storage.

--- a/python/contracts/messages/channels.py
+++ b/python/contracts/messages/channels.py
@@ -6,7 +6,8 @@ def channels_module():
     """Teia Channels Contract.
 
     Three-tier access (creator > admin > merkle user) with optional allowlist gating.
-    Channel-level governance via the Teia multisig contract.
+    Per-action fees, edit history, hide/delete separation, per-channel and
+    contract-wide ban lists, and channel + multisig moderation.
 
     Error codes:
 
@@ -21,6 +22,7 @@ def channels_module():
     - CONTENT_TOO_LARGE: Message content exceeds 32 KiB
     - PARENT_NOT_FOUND: Reply target message does not exist
     - PARENT_WRONG_CHANNEL: Reply target is in a different channel
+    - PARENT_HIDDEN: Reply target has been hidden
     - MESSAGE_NOT_FOUND: Message ID does not exist
     - UNDERFLOW: message_count would go negative
 
@@ -29,6 +31,14 @@ def channels_module():
     - NOT_CHANNEL_CREATOR: Caller is not the channel creator
     - NOT_CHANNEL_ADMIN: Caller is not creator or admin
     - TOO_MANY_ADMINS: Channel admin count would exceed 15
+
+    Ban:
+    - USER_BANNED: Caller is on the contract-wide ban list
+    - USER_BANNED_IN_CHANNEL: Caller is banned from this channel
+    - CANNOT_BAN_CREATOR: Cannot ban the channel creator
+
+    Version history:
+    - VERSION_NOT_FOUND: Requested version does not exist
 
     Access config / Merkle:
     - ALLOWLIST_NEEDS_ROOT: allowlist mode requires merkle_root
@@ -47,7 +57,7 @@ def channels_module():
     - CHANNELS_ALREADY_EXECUTED: Proposal already executed
     - CHANNELS_NOT_ENOUGH_VOTES: Positive votes below minimum
     """
-    
+
     # ===========================================================================
     # Types
     # ===========================================================================
@@ -62,7 +72,7 @@ def channels_module():
 
     merkle_step_type: type = sp.record(
         hash=sp.bytes,
-        direction=sp.nat,  # 0 = sibling is left, 1 = sibling is right
+        direction=sp.nat,
     )
 
     # --- Channel ---
@@ -85,8 +95,22 @@ def channels_module():
         sender=sp.address,
         content=sp.bytes,
         parent_id=sp.option[sp.nat],
+        hidden=sp.bool,
+        timestamp=sp.timestamp,
+        version=sp.nat,
+    )
+
+    # --- Message History ---
+
+    history_entry_type: type = sp.record(
+        channel_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
         timestamp=sp.timestamp,
     )
+
+    history_key_type: type = sp.pair[sp.nat, sp.nat]
 
     # --- Entrypoint Params ---
 
@@ -124,15 +148,34 @@ def channels_module():
         to_remove=sp.list[sp.address],
     )
 
+    edit_message_params_type: type = sp.record(
+        message_id=sp.nat,
+        content=sp.bytes,
+    )
+
+    set_own_message_hidden_params_type: type = sp.record(
+        message_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    moderate_message_hidden_params_type: type = sp.record(
+        message_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    set_channel_banned_params_type: type = sp.record(
+        channel_id=sp.nat,
+        address=sp.address,
+        banned=sp.bool,
+    )
+
     # --- Storage Types ---
 
     channels_map_type: type = sp.big_map[sp.nat, channel_type]
     messages_map_type: type = sp.big_map[sp.nat, message_type]
-    # Used as the input record for the is_channel_admin view.
     channel_admin_key_type: type = sp.record(channel_id=sp.nat, address=sp.address)
-    # One set of admin addresses per channel. sp.len() of the set enforces the
-    # 15-admin cap directly. Always initialised (possibly empty) on create_channel.
     channel_admins_map_type: type = sp.big_map[sp.nat, sp.set[sp.address]]
+    channel_banned_key_type: type = sp.pair[sp.nat, sp.address]
     metadata_type: type = sp.big_map[sp.string, sp.bytes]
 
     # --- Governance Types ---
@@ -142,13 +185,21 @@ def channels_module():
         value=sp.bytes,
     ).layout(("key", "value"))
 
+    user_banned_action_type: type = sp.record(
+        address=sp.address,
+        banned=sp.bool,
+    ).layout(("address", "banned"))
+
     proposal_action_type: type = sp.variant(
         set_pause=sp.bool,
-        set_message_fee=sp.mutez,
+        set_post_fee=sp.mutez,
+        set_edit_fee=sp.mutez,
+        set_hide_fee=sp.mutez,
         set_channel_fee=sp.mutez,
         set_fee_recipient=sp.address,
         update_multisig_address=sp.address,
         update_metadata=metadata_entry_type,
+        set_user_banned=user_banned_action_type,
     )
 
     proposal_type: type = sp.record(
@@ -183,18 +234,24 @@ def channels_module():
     # ===========================================================================
 
     class Channels(sp.Contract):
-        """Teia Channels — three-tier access (creator/admin/merkle user) with optional allowlist."""
+        """Teia Channels — three-tier access with hide/delete separation,
+        edit history, per-action fees, ban lists, and multisig super moderation."""
 
-        def __init__(self, multisig_address, fee_recipient, message_fee, channel_fee, metadata, counter):
+        def __init__(self, multisig_address, fee_recipient, post_fee, edit_fee, hide_fee, channel_fee, metadata, counter):
             self.data.multisig_address = sp.cast(multisig_address, sp.address)
             self.data.metadata = sp.cast(metadata, metadata_type)
             self.data.paused = False
             self.data.channels = sp.cast(sp.big_map(), channels_map_type)
             self.data.messages = sp.cast(sp.big_map(), messages_map_type)
+            self.data.message_history = sp.cast(sp.big_map(), sp.big_map[history_key_type, history_entry_type])
             self.data.channel_admins = sp.cast(sp.big_map(), channel_admins_map_type)
+            self.data.channel_banned = sp.cast(sp.big_map(), sp.big_map[channel_banned_key_type, sp.unit])
+            self.data.banned = sp.cast(sp.big_map(), sp.big_map[sp.address, sp.unit])
             self.data.channel_id_counter = sp.nat(1)
             self.data.message_id_counter = sp.nat(1)
-            self.data.message_fee = sp.cast(message_fee, sp.mutez)
+            self.data.post_fee = sp.cast(post_fee, sp.mutez)
+            self.data.edit_fee = sp.cast(edit_fee, sp.mutez)
+            self.data.hide_fee = sp.cast(hide_fee, sp.mutez)
             self.data.channel_fee = sp.cast(channel_fee, sp.mutez)
             self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
             self.data.proposals = sp.cast(sp.big_map(), sp.big_map[sp.nat, proposal_type])
@@ -211,7 +268,6 @@ def channels_module():
 
         @sp.private(with_storage="read-only")
         def _validate_access_config(self, params):
-            """Assert that access_mode and merkle_root are consistent."""
             sp.cast(params, sp.record(access_mode=access_mode_type, merkle_root=sp.option[sp.bytes]))
             if params.access_mode.is_variant.allowlist():
                 assert params.merkle_root.is_some(), "ALLOWLIST_NEEDS_ROOT"
@@ -221,6 +277,16 @@ def channels_module():
         @sp.private(with_storage="read-only")
         def _check_no_tez_transfer(self):
             assert sp.amount == sp.tez(0), "TEZ_TRANSFER"
+
+        @sp.private(with_storage="read-only")
+        def _check_not_banned(self):
+            assert not (sp.sender in self.data.banned), "USER_BANNED"
+
+        @sp.private(with_storage="read-only")
+        def _check_not_channel_banned(self, channel_id):
+            sp.cast(channel_id, sp.nat)
+            channel_ban_key = (channel_id, sp.sender)
+            assert not (channel_ban_key in self.data.channel_banned), "USER_BANNED_IN_CHANNEL"
 
         @sp.private(with_storage="read-only")
         def _check_is_user(self):
@@ -249,27 +315,23 @@ def channels_module():
                 (),
                 sp.nat,
             ).unwrap_some(error="CHANNELS_GET_EXPIRATION_FAILED")
-
             expiration_seconds = sp.to_int(expiration_days * 86400)
             expiration_time = sp.add_seconds(timestamp, expiration_seconds)
             assert not (sp.now > expiration_time), "CHANNELS_PROPOSAL_EXPIRED"
 
         @sp.private(with_storage="read-write", with_operations=True)
         def _send_fee(self, fee):
-            """Sends fee to fee_recipient if > 0."""
             if fee > sp.mutez(0):
                 sp.send(self.data.fee_recipient, fee)
 
         @sp.private(with_storage="read-only")
         def _check_channel_admin(self, channel_id):
-            """Assert sender is channel creator or channel admin."""
             sp.cast(channel_id, sp.nat)
             channel = self.data.channels[channel_id]
             assert channel.creator == sp.sender or sp.sender in self.data.channel_admins[channel_id], "NOT_CHANNEL_ADMIN"
 
         @sp.private(with_storage="read-write")
         def _write_message(self, params):
-            """Writes a message and increments counters."""
             sp.cast(params, write_message_params_type)
             message_id = self.data.message_id_counter
             self.data.messages[message_id] = sp.record(
@@ -277,7 +339,9 @@ def channels_module():
                 sender=sp.sender,
                 content=params.content,
                 parent_id=params.parent_id,
+                hidden=False,
                 timestamp=sp.now,
+                version=sp.nat(1),
             )
 
             channel = self.data.channels[params.channel_id]
@@ -297,8 +361,6 @@ def channels_module():
 
         @sp.private(with_storage="read-only")
         def _check_can_post(self, params):
-            """Assert sender can post: creator, admin, or valid merkle proof in allowlist mode.
-            Closed channels reject all non-privileged posters."""
             sp.cast(params, sp.record(channel_id=sp.nat, proof=sp.option[sp.list[merkle_step_type]]))
             channel = self.data.channels[params.channel_id]
             is_privileged = channel.creator == sp.sender or sp.sender in self.data.channel_admins[params.channel_id]
@@ -322,7 +384,6 @@ def channels_module():
 
         @sp.entrypoint
         def create_channel(self, params):
-            """Create a new channel with initial configuration. Anyone can create."""
             sp.cast(params, create_channel_params_type)
             self._check_not_paused()
             assert sp.len(params.metadata_uri) > 0, "EMPTY_METADATA"
@@ -342,8 +403,6 @@ def channels_module():
                 timestamp=sp.now,
             )
 
-            # Build the admin set, deduping any repeats in the input list, then
-            # enforce the 15-admin cap on the resulting set size.
             admins_set = sp.cast(set(), sp.set[sp.address])
             for addr in params.admins:
                 admins_set.add(addr)
@@ -370,15 +429,19 @@ def channels_module():
 
         @sp.entrypoint
         def configure_channel(self, params):
-            """Set access mode and Merkle root. Creator or admin."""
+            """Closed channels: creator only. Other modes: creator or admin."""
             sp.cast(params, configure_channel_params_type)
             self._check_not_paused()
             self._check_no_tez_transfer()
 
             assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
             channel = self.data.channels[params.channel_id]
-            self._check_channel_admin(params.channel_id)
             assert not channel.hidden, "CHANNEL_HIDDEN"
+
+            if channel.access_mode.is_variant.closed():
+                assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
+            else:
+                self._check_channel_admin(params.channel_id)
 
             self._validate_access_config(sp.record(access_mode=params.access_mode, merkle_root=params.merkle_root))
 
@@ -405,124 +468,7 @@ def channels_module():
             )
 
         @sp.entrypoint
-        def update_channel_admins(self, params):
-            """Add or remove channel admins. Creator only."""
-            sp.cast(params, update_channel_admins_params_type)
-            self._check_not_paused()
-            self._check_no_tez_transfer()
-
-            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
-            channel = self.data.channels[params.channel_id]
-            assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
-
-            # Apply removals first, then additions, so a creator can swap
-            # admins (remove one, add another) without temporarily exceeding 15.
-            for addr in params.to_remove:
-                if addr in self.data.channel_admins[params.channel_id]:
-                    self.data.channel_admins[params.channel_id].remove(addr)
-
-            for addr in params.to_add:
-                self.data.channel_admins[params.channel_id].add(addr)
-
-            assert sp.len(self.data.channel_admins[params.channel_id]) <= sp.nat(15), "TOO_MANY_ADMINS"
-
-            sp.emit(
-                sp.record(
-                    channel_id=params.channel_id,
-                    to_add=params.to_add,
-                    to_remove=params.to_remove,
-                ),
-                tag="channel_admins_updated",
-            )
-
-        @sp.entrypoint
-        def post_message(self, params):
-            """Post a message to a channel."""
-            sp.cast(params, post_message_params_type)
-            self._check_not_paused()
-
-            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
-            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
-            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
-
-            channel = self.data.channels[params.channel_id]
-            assert not channel.hidden, "CHANNEL_HIDDEN"
-
-            # Validate parent message if replying
-            if params.parent_id.is_some():
-                parent_msg_id = params.parent_id.unwrap_some()
-                assert parent_msg_id in self.data.messages, "PARENT_NOT_FOUND"
-                parent_msg = self.data.messages[parent_msg_id]
-                assert parent_msg.channel_id == params.channel_id, "PARENT_WRONG_CHANNEL"
-
-            self._check_can_post(sp.record(channel_id=params.channel_id, proof=params.proof))
-
-            # Fee
-            assert sp.amount == self.data.message_fee, "INCORRECT_FEE"
-            self._send_fee(self.data.message_fee)
-
-            message_id = self._write_message(sp.record(channel_id=params.channel_id, content=params.content, parent_id=params.parent_id))
-
-            # Note: `content` is intentionally NOT emitted in the event so that
-            # `delete_message` actually deletes — events are part of permanent block
-            # history. Indexers should read content from the `messages` big_map.
-            sp.emit(
-                sp.record(
-                    channel_id=params.channel_id,
-                    message_id=message_id,
-                    sender=sp.sender,
-                    parent_id=params.parent_id,
-                    timestamp=sp.now,
-                ),
-                tag="message_posted",
-            )
-
-        @sp.entrypoint
-        def delete_message(self, message_id):
-            """Delete a message. In closed channels: sender only.
-            In unrestricted/allowlist channels: sender or channel creator."""
-            sp.cast(message_id, sp.nat)
-            self._check_not_paused()
-            self._check_no_tez_transfer()
-
-            assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
-            message = self.data.messages[message_id]
-
-            assert message.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
-            channel = self.data.channels[message.channel_id]
-
-            if channel.access_mode.is_variant.closed():
-                assert message.sender == sp.sender, "NOT_AUTHORIZED"
-            else:
-                is_sender = message.sender == sp.sender
-                is_creator = channel.creator == sp.sender
-                assert is_sender or is_creator, "NOT_AUTHORIZED"
-
-            self.data.channels[message.channel_id] = sp.record(
-                creator=channel.creator,
-                metadata_uri=channel.metadata_uri,
-                access_mode=channel.access_mode,
-                merkle_root=channel.merkle_root,
-                merkle_uri=channel.merkle_uri,
-                message_count=sp.as_nat(channel.message_count - 1, error="UNDERFLOW"),
-                hidden=channel.hidden,
-                timestamp=channel.timestamp,
-            )
-
-            del self.data.messages[message_id]
-
-            sp.emit(
-                sp.record(
-                    channel_id=message.channel_id,
-                    message_id=message_id,
-                    deleted_by=sp.sender,
-                ),
-                tag="message_deleted",
-            )
-
-        @sp.entrypoint
         def update_channel(self, params):
-            """Update channel metadata. Creator or admin."""
             sp.cast(params, sp.record(channel_id=sp.nat, metadata_uri=sp.bytes))
             self._check_not_paused()
             self._check_no_tez_transfer()
@@ -554,7 +500,6 @@ def channels_module():
 
         @sp.entrypoint
         def set_channel_hidden(self, params):
-            """Set a channel's hidden state (soft delete / restore). Creator only."""
             sp.cast(params, sp.record(channel_id=sp.nat, hidden=sp.bool))
             self._check_not_paused()
             self._check_no_tez_transfer()
@@ -583,13 +528,290 @@ def channels_module():
                 tag="channel_hidden_set",
             )
 
+        @sp.entrypoint
+        def update_channel_admins(self, params):
+            sp.cast(params, update_channel_admins_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
+
+            for addr in params.to_remove:
+                if addr in self.data.channel_admins[params.channel_id]:
+                    self.data.channel_admins[params.channel_id].remove(addr)
+
+            for addr in params.to_add:
+                self.data.channel_admins[params.channel_id].add(addr)
+
+            assert sp.len(self.data.channel_admins[params.channel_id]) <= sp.nat(15), "TOO_MANY_ADMINS"
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    to_add=params.to_add,
+                    to_remove=params.to_remove,
+                ),
+                tag="channel_admins_updated",
+            )
+
+        @sp.entrypoint
+        def set_channel_banned(self, params):
+            sp.cast(params, set_channel_banned_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            self._check_channel_admin(params.channel_id)
+            assert params.address != channel.creator, "CANNOT_BAN_CREATOR"
+
+            if params.banned:
+                self.data.channel_banned[(params.channel_id, params.address)] = ()
+            else:
+                if (params.channel_id, params.address) in self.data.channel_banned:
+                    del self.data.channel_banned[(params.channel_id, params.address)]
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    address=params.address,
+                    banned=params.banned,
+                    updated_by=sp.sender,
+                ),
+                tag="channel_banned_set",
+            )
+
+        # =======================================================================
+        # Message Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def post_message(self, params):
+            sp.cast(params, post_message_params_type)
+            self._check_not_paused()
+            self._check_not_banned()
+
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+
+            channel = self.data.channels[params.channel_id]
+            assert not channel.hidden, "CHANNEL_HIDDEN"
+
+            if channel.creator != sp.sender:
+                self._check_not_channel_banned(params.channel_id)
+
+            if params.parent_id.is_some():
+                parent_msg_id = params.parent_id.unwrap_some()
+                assert parent_msg_id in self.data.messages, "PARENT_NOT_FOUND"
+                parent_msg = self.data.messages[parent_msg_id]
+                assert parent_msg.channel_id == params.channel_id, "PARENT_WRONG_CHANNEL"
+                assert not parent_msg.hidden, "PARENT_HIDDEN"
+
+            self._check_can_post(sp.record(channel_id=params.channel_id, proof=params.proof))
+
+            assert sp.amount == self.data.post_fee, "INCORRECT_FEE"
+            self._send_fee(self.data.post_fee)
+
+            message_id = self._write_message(sp.record(channel_id=params.channel_id, content=params.content, parent_id=params.parent_id))
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    message_id=message_id,
+                    sender=sp.sender,
+                    parent_id=params.parent_id,
+                    timestamp=sp.now,
+                ),
+                tag="message_posted",
+            )
+
+        @sp.entrypoint
+        def edit_message(self, params):
+            sp.cast(params, edit_message_params_type)
+            self._check_not_paused()
+            self._check_not_banned()
+
+            assert sp.amount == self.data.edit_fee, "INCORRECT_FEE"
+
+            assert params.message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[params.message_id]
+            assert message.sender == sp.sender, "NOT_AUTHORIZED"
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+
+            self.data.message_history[(params.message_id, message.version)] = sp.record(
+                channel_id=message.channel_id,
+                sender=message.sender,
+                content=message.content,
+                parent_id=message.parent_id,
+                timestamp=message.timestamp,
+            )
+
+            new_version = message.version + 1
+            self.data.messages[params.message_id] = sp.record(
+                channel_id=message.channel_id,
+                sender=message.sender,
+                content=params.content,
+                parent_id=message.parent_id,
+                hidden=message.hidden,
+                timestamp=sp.now,
+                version=new_version,
+            )
+
+            self._send_fee(sp.amount)
+
+            sp.emit(
+                sp.record(
+                    channel_id=message.channel_id,
+                    message_id=params.message_id,
+                    sender=message.sender,
+                    parent_id=message.parent_id,
+                    timestamp=sp.now,
+                    version=new_version,
+                ),
+                tag="message_edited",
+            )
+
+        @sp.entrypoint
+        def delete_message(self, message_id):
+            """Sender-only hard delete, regardless of channel access mode."""
+            sp.cast(message_id, sp.nat)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[message_id]
+            assert message.sender == sp.sender, "NOT_AUTHORIZED"
+
+            assert message.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[message.channel_id]
+
+            self.data.channels[message.channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=channel.metadata_uri,
+                access_mode=channel.access_mode,
+                merkle_root=channel.merkle_root,
+                merkle_uri=channel.merkle_uri,
+                message_count=sp.as_nat(channel.message_count - 1, error="UNDERFLOW"),
+                hidden=channel.hidden,
+                timestamp=channel.timestamp,
+            )
+
+            del self.data.messages[message_id]
+
+            sp.emit(
+                sp.record(
+                    channel_id=message.channel_id,
+                    message_id=message_id,
+                    deleted_by=sp.sender,
+                ),
+                tag="message_deleted",
+            )
+
+        @sp.entrypoint
+        def set_own_message_hidden(self, params):
+            sp.cast(params, set_own_message_hidden_params_type)
+            self._check_not_paused()
+
+            assert sp.amount == self.data.hide_fee, "INCORRECT_FEE"
+
+            assert params.message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[params.message_id]
+            assert message.sender == sp.sender, "NOT_AUTHORIZED"
+
+            self.data.messages[params.message_id] = sp.record(
+                channel_id=message.channel_id,
+                sender=message.sender,
+                content=message.content,
+                parent_id=message.parent_id,
+                hidden=params.hidden,
+                timestamp=message.timestamp,
+                version=message.version,
+            )
+
+            self._send_fee(sp.amount)
+
+            sp.emit(
+                sp.record(
+                    message_id=params.message_id,
+                    hidden=params.hidden,
+                    updated_by=sp.sender,
+                ),
+                tag="message_hidden_set",
+            )
+
+        @sp.entrypoint
+        def moderate_message_hidden(self, params):
+            """Channel creator or admin can hide any message in their channel."""
+            sp.cast(params, moderate_message_hidden_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[params.message_id]
+
+            assert message.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            self._check_channel_admin(message.channel_id)
+
+            self.data.messages[params.message_id] = sp.record(
+                channel_id=message.channel_id,
+                sender=message.sender,
+                content=message.content,
+                parent_id=message.parent_id,
+                hidden=params.hidden,
+                timestamp=message.timestamp,
+                version=message.version,
+            )
+
+            sp.emit(
+                sp.record(
+                    channel_id=message.channel_id,
+                    message_id=params.message_id,
+                    hidden=params.hidden,
+                    moderator=sp.sender,
+                ),
+                tag="message_moderated",
+            )
+
+        @sp.entrypoint
+        def multisig_moderate_msg_hidden(self, params):
+            """Any multisig user can hide any message in any channel."""
+            sp.cast(params, moderate_message_hidden_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            assert params.message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[params.message_id]
+
+            self.data.messages[params.message_id] = sp.record(
+                channel_id=message.channel_id,
+                sender=message.sender,
+                content=message.content,
+                parent_id=message.parent_id,
+                hidden=params.hidden,
+                timestamp=message.timestamp,
+                version=message.version,
+            )
+
+            sp.emit(
+                sp.record(
+                    channel_id=message.channel_id,
+                    message_id=params.message_id,
+                    hidden=params.hidden,
+                    moderator=sp.sender,
+                ),
+                tag="message_multisig_moderated",
+            )
+
         # =======================================================================
         # Governance Entrypoints
         # =======================================================================
 
         @sp.entrypoint
         def submit_proposal(self, action):
-            """Submit a new proposal."""
             sp.cast(action, proposal_action_type)
             self._check_no_tez_transfer()
             self._check_is_user()
@@ -606,7 +828,6 @@ def channels_module():
 
         @sp.entrypoint
         def vote_proposal(self, vote):
-            """Vote on an existing proposal."""
             sp.cast(vote, vote_params_type)
             self._check_no_tez_transfer()
             self._check_is_user()
@@ -634,7 +855,6 @@ def channels_module():
 
         @sp.entrypoint
         def execute_proposal(self, proposal_id):
-            """Execute an approved proposal."""
             sp.cast(proposal_id, sp.nat)
             self._check_no_tez_transfer()
             self._check_is_user()
@@ -651,22 +871,109 @@ def channels_module():
 
             if proposal.action.is_variant.set_pause():
                 self.data.paused = proposal.action.unwrap.set_pause()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        paused=self.data.paused,
+                        updated_by=sp.sender,
+                    ),
+                    tag="pause_set",
+                )
 
-            if proposal.action.is_variant.set_message_fee():
-                self.data.message_fee = proposal.action.unwrap.set_message_fee()
+            if proposal.action.is_variant.set_post_fee():
+                self.data.post_fee = proposal.action.unwrap.set_post_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        post_fee=self.data.post_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="post_fee_set",
+                )
+
+            if proposal.action.is_variant.set_edit_fee():
+                self.data.edit_fee = proposal.action.unwrap.set_edit_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        edit_fee=self.data.edit_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="edit_fee_set",
+                )
+
+            if proposal.action.is_variant.set_hide_fee():
+                self.data.hide_fee = proposal.action.unwrap.set_hide_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        hide_fee=self.data.hide_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="hide_fee_set",
+                )
 
             if proposal.action.is_variant.set_channel_fee():
                 self.data.channel_fee = proposal.action.unwrap.set_channel_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        channel_fee=self.data.channel_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="channel_fee_set",
+                )
 
             if proposal.action.is_variant.set_fee_recipient():
                 self.data.fee_recipient = proposal.action.unwrap.set_fee_recipient()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        fee_recipient=self.data.fee_recipient,
+                        updated_by=sp.sender,
+                    ),
+                    tag="fee_recipient_set",
+                )
 
             if proposal.action.is_variant.update_multisig_address():
                 self.data.multisig_address = proposal.action.unwrap.update_multisig_address()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        multisig_address=self.data.multisig_address,
+                        updated_by=sp.sender,
+                    ),
+                    tag="multisig_address_set",
+                )
 
             if proposal.action.is_variant.update_metadata():
                 entry = proposal.action.unwrap.update_metadata()
                 self.data.metadata[entry.key] = entry.value
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        key=entry.key,
+                        updated_by=sp.sender,
+                    ),
+                    tag="metadata_updated",
+                )
+
+            if proposal.action.is_variant.set_user_banned():
+                ban = proposal.action.unwrap.set_user_banned()
+                if ban.banned:
+                    self.data.banned[ban.address] = ()
+                else:
+                    if ban.address in self.data.banned:
+                        del self.data.banned[ban.address]
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        address=ban.address,
+                        banned=ban.banned,
+                        updated_by=sp.sender,
+                    ),
+                    tag="user_banned_set",
+                )
 
         # =======================================================================
         # Views
@@ -674,105 +981,126 @@ def channels_module():
 
         @sp.onchain_view()
         def get_channel(self, channel_id):
-            """Get channel by ID."""
             sp.cast(channel_id, sp.nat)
             assert channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
             return self.data.channels[channel_id]
 
         @sp.onchain_view()
         def get_message(self, message_id):
-            """Get message by ID."""
             sp.cast(message_id, sp.nat)
             assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
             return self.data.messages[message_id]
 
         @sp.onchain_view()
-        def get_message_fee(self):
-            """Get the current message fee."""
-            return self.data.message_fee
+        def get_message_version(self, key):
+            sp.cast(key, history_key_type)
+            assert key in self.data.message_history, "VERSION_NOT_FOUND"
+            return self.data.message_history[key]
 
         @sp.onchain_view()
-        def get_channel_fee(self):
-            """Get the current channel creation fee."""
-            return self.data.channel_fee
+        def get_message_version_count(self, message_id):
+            sp.cast(message_id, sp.nat)
+            assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            return self.data.messages[message_id].version
+
+        @sp.onchain_view()
+        def get_fees(self):
+            return sp.record(
+                post_fee=self.data.post_fee,
+                edit_fee=self.data.edit_fee,
+                hide_fee=self.data.hide_fee,
+                channel_fee=self.data.channel_fee,
+            )
 
         @sp.onchain_view()
         def is_channel_admin(self, params):
-            """Check if an address is a channel admin (or creator)."""
             sp.cast(params, channel_admin_key_type)
             assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
             channel = self.data.channels[params.channel_id]
             return channel.creator == params.address or params.address in self.data.channel_admins[params.channel_id]
 
         @sp.onchain_view()
+        def is_banned(self, address):
+            sp.cast(address, sp.address)
+            return address in self.data.banned
+
+        @sp.onchain_view()
+        def is_channel_banned(self, params):
+            sp.cast(params, channel_admin_key_type)
+            return (params.channel_id, params.address) in self.data.channel_banned
+
+        @sp.onchain_view()
         def get_proposal(self, proposal_id):
-            """Get proposal by ID."""
             sp.cast(proposal_id, sp.nat)
             assert proposal_id in self.data.proposals, "CHANNELS_NO_PROPOSAL"
             return self.data.proposals[proposal_id]
 
         @sp.onchain_view()
         def get_vote(self, key):
-            """Get vote by key (proposal_id, voter)."""
             sp.cast(key, vote_key_type)
             return self.data.votes.get(key, default=False)
 
 
-
 # ==============================================================================
-# Deployment Scenario
+# Deployment Scenarios
 # ==============================================================================
-
 
 
 @sp.add_test()
-def channel_deploy_shadownet():
-    """Deployment scenario."""
-    scenario = sp.test_scenario("channel_deploy_shadownet", channels_module)
-    scenario.h1("Channel Merkle - Deployment Shadownet")
+def channels_deploy_shadownet():
+    scenario = sp.test_scenario("channels_deploy_shadownet", channels_module)
+    scenario.h1("Teia Channels - Deployment Shadownet")
 
     MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
     FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
-    MESSAGE_FEE = sp.mutez(25000)
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
     CHANNEL_FEE = sp.mutez(100000)
 
     contract_metadata = sp.big_map(
         {
-            "": sp.scenario_utils.bytes_of_string("ipfs://bafkreia2utxnnxyxwbtpb56bpfebby732h57xvzvuauai6kjvjrd6qfmxe"),
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmcgWNSbBDqe2Q1Nmpg6crsAV7QDjXAQpAxQuLcWW2ffFC"),
         }
     )
 
     contract = channels_module.Channels(
         multisig_address=MULTISIG_ADDRESS,
         fee_recipient=FEE_RECIPIENT_ADDRESS,
-        message_fee=MESSAGE_FEE,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
         channel_fee=CHANNEL_FEE,
         metadata=contract_metadata,
         counter=sp.nat(0),
     )
     scenario += contract
 
+
 @sp.add_test()
-def channel_deploy_mainnet():
-    """Deployment scenario for Tezos mainnet."""
-    scenario = sp.test_scenario("channel_deploy_mainnet", channels_module)
+def channels_deploy_mainnet():
+    scenario = sp.test_scenario("channels_deploy_mainnet", channels_module)
     scenario.h1("Teia Channels - Deployment Mainnet")
 
     MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
     FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
-    MESSAGE_FEE = sp.mutez(25000)
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
     CHANNEL_FEE = sp.mutez(100000)
 
     contract_metadata = sp.big_map(
         {
-            "": sp.scenario_utils.bytes_of_string("ipfs://bafkreia2utxnnxyxwbtpb56bpfebby732h57xvzvuauai6kjvjrd6qfmxe"),
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmcgWNSbBDqe2Q1Nmpg6crsAV7QDjXAQpAxQuLcWW2ffFC"),
         }
     )
 
     contract = channels_module.Channels(
         multisig_address=MULTISIG_ADDRESS,
         fee_recipient=FEE_RECIPIENT_ADDRESS,
-        message_fee=MESSAGE_FEE,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
         channel_fee=CHANNEL_FEE,
         metadata=contract_metadata,
         counter=sp.nat(0),

--- a/python/contracts/messages/channels.py
+++ b/python/contracts/messages/channels.py
@@ -751,3 +751,30 @@ def channel_deploy_shadownet():
         counter=sp.nat(0),
     )
     scenario += contract
+
+@sp.add_test()
+def channel_deploy_mainnet():
+    """Deployment scenario for Tezos mainnet."""
+    scenario = sp.test_scenario("channel_deploy_mainnet", channels_module)
+    scenario.h1("Teia Channels - Deployment Mainnet")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(25000)
+    CHANNEL_FEE = sp.mutez(100000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://bafkreia2utxnnxyxwbtpb56bpfebby732h57xvzvuauai6kjvjrd6qfmxe"),
+        }
+    )
+
+    contract = channels_module.Channels(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        channel_fee=CHANNEL_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract

--- a/python/contracts/messages/channels.py
+++ b/python/contracts/messages/channels.py
@@ -1,0 +1,751 @@
+import smartpy as sp
+
+
+@sp.module
+def channels_module():
+    """Teia Channels Contract.
+
+    Three-tier access (creator > admin > merkle user) with optional allowlist gating.
+    Channel-level governance via the Teia multisig contract.
+
+    Error codes:
+
+    Channel / message:
+    - CONTRACT_PAUSED: Contract is globally paused
+    - TEZ_TRANSFER: Unexpected tez transfer
+    - INCORRECT_FEE: sp.amount does not match the required fee
+    - CHANNEL_NOT_FOUND: Channel ID does not exist
+    - CHANNEL_HIDDEN: Channel has been hidden
+    - EMPTY_METADATA: metadata_uri is empty
+    - EMPTY_CONTENT: Message content is empty
+    - CONTENT_TOO_LARGE: Message content exceeds 32 KiB
+    - PARENT_NOT_FOUND: Reply target message does not exist
+    - PARENT_WRONG_CHANNEL: Reply target is in a different channel
+    - MESSAGE_NOT_FOUND: Message ID does not exist
+    - UNDERFLOW: message_count would go negative
+
+    Authorization:
+    - NOT_AUTHORIZED: Caller cannot perform this action
+    - NOT_CHANNEL_CREATOR: Caller is not the channel creator
+    - NOT_CHANNEL_ADMIN: Caller is not creator or admin
+    - TOO_MANY_ADMINS: Channel admin count would exceed 15
+
+    Access config / Merkle:
+    - ALLOWLIST_NEEDS_ROOT: allowlist mode requires merkle_root
+    - ROOT_NOT_ALLOWED: non-allowlist modes must not set merkle_root
+    - NO_MERKLE_ROOT: Channel has no merkle_root configured
+    - PROOF_REQUIRED: Caller must supply a merkle proof
+    - INVALID_MERKLE_PROOF: Provided proof does not match merkle_root
+
+    Governance (multisig-gated):
+    - CHANNELS_VIEW_FAILED: is_user view on multisig failed
+    - CHANNELS_NOT_MULTISIG_USER: Caller is not a multisig user
+    - CHANNELS_GET_MIN_VOTES_FAILED: get_minimum_votes view failed
+    - CHANNELS_GET_EXPIRATION_FAILED: get_expiration_time view failed
+    - CHANNELS_PROPOSAL_EXPIRED: Proposal past expiration window
+    - CHANNELS_NO_PROPOSAL: Proposal ID does not exist
+    - CHANNELS_ALREADY_EXECUTED: Proposal already executed
+    - CHANNELS_NOT_ENOUGH_VOTES: Positive votes below minimum
+    """
+    
+    # ===========================================================================
+    # Types
+    # ===========================================================================
+
+    # --- Access Control ---
+
+    access_mode_type: type = sp.variant(
+        unrestricted=sp.unit,
+        allowlist=sp.unit,
+        closed=sp.unit,
+    )
+
+    merkle_step_type: type = sp.record(
+        hash=sp.bytes,
+        direction=sp.nat,  # 0 = sibling is left, 1 = sibling is right
+    )
+
+    # --- Channel ---
+
+    channel_type: type = sp.record(
+        creator=sp.address,
+        metadata_uri=sp.bytes,
+        access_mode=access_mode_type,
+        merkle_root=sp.option[sp.bytes],
+        merkle_uri=sp.option[sp.bytes],
+        message_count=sp.nat,
+        hidden=sp.bool,
+        timestamp=sp.timestamp,
+    )
+
+    # --- Message ---
+
+    message_type: type = sp.record(
+        channel_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        timestamp=sp.timestamp,
+    )
+
+    # --- Entrypoint Params ---
+
+    post_message_params_type: type = sp.record(
+        channel_id=sp.nat,
+        content=sp.bytes,
+        proof=sp.option[sp.list[merkle_step_type]],
+        parent_id=sp.option[sp.nat],
+    )
+
+    create_channel_params_type: type = sp.record(
+        metadata_uri=sp.bytes,
+        access_mode=access_mode_type,
+        merkle_root=sp.option[sp.bytes],
+        merkle_uri=sp.option[sp.bytes],
+        admins=sp.list[sp.address],
+    )
+
+    configure_channel_params_type: type = sp.record(
+        channel_id=sp.nat,
+        access_mode=access_mode_type,
+        merkle_root=sp.option[sp.bytes],
+        merkle_uri=sp.option[sp.bytes],
+    )
+
+    write_message_params_type: type = sp.record(
+        channel_id=sp.nat,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+    )
+
+    update_channel_admins_params_type: type = sp.record(
+        channel_id=sp.nat,
+        to_add=sp.list[sp.address],
+        to_remove=sp.list[sp.address],
+    )
+
+    # --- Storage Types ---
+
+    channels_map_type: type = sp.big_map[sp.nat, channel_type]
+    messages_map_type: type = sp.big_map[sp.nat, message_type]
+    # Used as the input record for the is_channel_admin view.
+    channel_admin_key_type: type = sp.record(channel_id=sp.nat, address=sp.address)
+    # One set of admin addresses per channel. sp.len() of the set enforces the
+    # 15-admin cap directly. Always initialised (possibly empty) on create_channel.
+    channel_admins_map_type: type = sp.big_map[sp.nat, sp.set[sp.address]]
+    metadata_type: type = sp.big_map[sp.string, sp.bytes]
+
+    # --- Governance Types ---
+
+    metadata_entry_type: type = sp.record(
+        key=sp.string,
+        value=sp.bytes,
+    ).layout(("key", "value"))
+
+    proposal_action_type: type = sp.variant(
+        set_pause=sp.bool,
+        set_message_fee=sp.mutez,
+        set_channel_fee=sp.mutez,
+        set_fee_recipient=sp.address,
+        update_multisig_address=sp.address,
+        update_metadata=metadata_entry_type,
+    )
+
+    proposal_type: type = sp.record(
+        action=proposal_action_type,
+        executed=sp.bool,
+        issuer=sp.address,
+        timestamp=sp.timestamp,
+        positive_votes=sp.nat,
+        negative_votes=sp.nat,
+    ).layout(
+        (
+            "action",
+            (
+                "executed",
+                (
+                    "issuer",
+                    ("timestamp", ("positive_votes", "negative_votes")),
+                ),
+            ),
+        )
+    )
+
+    vote_key_type: type = sp.pair[sp.nat, sp.address]
+
+    vote_params_type: type = sp.record(
+        proposal_id=sp.nat,
+        approval=sp.bool,
+    ).layout(("proposal_id", "approval"))
+
+    # ===========================================================================
+    # Contract
+    # ===========================================================================
+
+    class Channels(sp.Contract):
+        """Teia Channels — three-tier access (creator/admin/merkle user) with optional allowlist."""
+
+        def __init__(self, multisig_address, fee_recipient, message_fee, channel_fee, metadata, counter):
+            self.data.multisig_address = sp.cast(multisig_address, sp.address)
+            self.data.metadata = sp.cast(metadata, metadata_type)
+            self.data.paused = False
+            self.data.channels = sp.cast(sp.big_map(), channels_map_type)
+            self.data.messages = sp.cast(sp.big_map(), messages_map_type)
+            self.data.channel_admins = sp.cast(sp.big_map(), channel_admins_map_type)
+            self.data.channel_id_counter = sp.nat(1)
+            self.data.message_id_counter = sp.nat(1)
+            self.data.message_fee = sp.cast(message_fee, sp.mutez)
+            self.data.channel_fee = sp.cast(channel_fee, sp.mutez)
+            self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
+            self.data.proposals = sp.cast(sp.big_map(), sp.big_map[sp.nat, proposal_type])
+            self.data.votes = sp.cast(sp.big_map(), sp.big_map[vote_key_type, sp.bool])
+            self.data.counter = sp.cast(counter, sp.nat)
+
+        # =======================================================================
+        # Private Helpers
+        # =======================================================================
+
+        @sp.private(with_storage="read-only")
+        def _check_not_paused(self):
+            assert not self.data.paused, "CONTRACT_PAUSED"
+
+        @sp.private(with_storage="read-only")
+        def _validate_access_config(self, params):
+            """Assert that access_mode and merkle_root are consistent."""
+            sp.cast(params, sp.record(access_mode=access_mode_type, merkle_root=sp.option[sp.bytes]))
+            if params.access_mode.is_variant.allowlist():
+                assert params.merkle_root.is_some(), "ALLOWLIST_NEEDS_ROOT"
+            else:
+                assert not params.merkle_root.is_some(), "ROOT_NOT_ALLOWED"
+
+        @sp.private(with_storage="read-only")
+        def _check_no_tez_transfer(self):
+            assert sp.amount == sp.tez(0), "TEZ_TRANSFER"
+
+        @sp.private(with_storage="read-only")
+        def _check_is_user(self):
+            is_user = sp.view(
+                "is_user",
+                self.data.multisig_address,
+                sp.sender,
+                sp.bool,
+            ).unwrap_some(error="CHANNELS_VIEW_FAILED")
+            assert is_user, "CHANNELS_NOT_MULTISIG_USER"
+
+        @sp.private(with_storage="read-only")
+        def _get_minimum_votes(self):
+            return sp.view(
+                "get_minimum_votes",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="CHANNELS_GET_MIN_VOTES_FAILED")
+
+        @sp.private(with_storage="read-only")
+        def _check_not_expired(self, timestamp):
+            expiration_days = sp.view(
+                "get_expiration_time",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="CHANNELS_GET_EXPIRATION_FAILED")
+
+            expiration_seconds = sp.to_int(expiration_days * 86400)
+            expiration_time = sp.add_seconds(timestamp, expiration_seconds)
+            assert not (sp.now > expiration_time), "CHANNELS_PROPOSAL_EXPIRED"
+
+        @sp.private(with_storage="read-write", with_operations=True)
+        def _send_fee(self, fee):
+            """Sends fee to fee_recipient if > 0."""
+            if fee > sp.mutez(0):
+                sp.send(self.data.fee_recipient, fee)
+
+        @sp.private(with_storage="read-only")
+        def _check_channel_admin(self, channel_id):
+            """Assert sender is channel creator or channel admin."""
+            sp.cast(channel_id, sp.nat)
+            channel = self.data.channels[channel_id]
+            assert channel.creator == sp.sender or sp.sender in self.data.channel_admins[channel_id], "NOT_CHANNEL_ADMIN"
+
+        @sp.private(with_storage="read-write")
+        def _write_message(self, params):
+            """Writes a message and increments counters."""
+            sp.cast(params, write_message_params_type)
+            message_id = self.data.message_id_counter
+            self.data.messages[message_id] = sp.record(
+                channel_id=params.channel_id,
+                sender=sp.sender,
+                content=params.content,
+                parent_id=params.parent_id,
+                timestamp=sp.now,
+            )
+
+            channel = self.data.channels[params.channel_id]
+            self.data.channels[params.channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=channel.metadata_uri,
+                access_mode=channel.access_mode,
+                merkle_root=channel.merkle_root,
+                merkle_uri=channel.merkle_uri,
+                message_count=channel.message_count + 1,
+                hidden=channel.hidden,
+                timestamp=channel.timestamp,
+            )
+
+            self.data.message_id_counter += 1
+            return message_id
+
+        @sp.private(with_storage="read-only")
+        def _check_can_post(self, params):
+            """Assert sender can post: creator, admin, or valid merkle proof in allowlist mode.
+            Closed channels reject all non-privileged posters."""
+            sp.cast(params, sp.record(channel_id=sp.nat, proof=sp.option[sp.list[merkle_step_type]]))
+            channel = self.data.channels[params.channel_id]
+            is_privileged = channel.creator == sp.sender or sp.sender in self.data.channel_admins[params.channel_id]
+            if not is_privileged:
+                if channel.access_mode.is_variant.closed():
+                    assert False, "NOT_AUTHORIZED"
+                if channel.access_mode.is_variant.allowlist():
+                    root = channel.merkle_root.unwrap_some(error="NO_MERKLE_ROOT")
+                    proof = params.proof.unwrap_some(error="PROOF_REQUIRED")
+                    computed = sp.blake2b(sp.pack(sp.sender))
+                    for step in proof:
+                        if step.direction == 0:
+                            computed = sp.blake2b(step.hash + computed)
+                        else:
+                            computed = sp.blake2b(computed + step.hash)
+                    assert computed == root, "INVALID_MERKLE_PROOF"
+
+        # =======================================================================
+        # Channel Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def create_channel(self, params):
+            """Create a new channel with initial configuration. Anyone can create."""
+            sp.cast(params, create_channel_params_type)
+            self._check_not_paused()
+            assert sp.len(params.metadata_uri) > 0, "EMPTY_METADATA"
+            assert sp.amount == self.data.channel_fee, "INCORRECT_FEE"
+
+            self._validate_access_config(sp.record(access_mode=params.access_mode, merkle_root=params.merkle_root))
+            self._send_fee(self.data.channel_fee)
+
+            channel_id = self.data.channel_id_counter
+            self.data.channels[channel_id] = sp.record(
+                creator=sp.sender,
+                metadata_uri=params.metadata_uri,
+                access_mode=params.access_mode,
+                merkle_root=params.merkle_root,
+                merkle_uri=params.merkle_uri,
+                message_count=sp.nat(0),
+                hidden=False,
+                timestamp=sp.now,
+            )
+
+            # Build the admin set, deduping any repeats in the input list, then
+            # enforce the 15-admin cap on the resulting set size.
+            admins_set = sp.cast(set(), sp.set[sp.address])
+            for addr in params.admins:
+                admins_set.add(addr)
+            assert sp.len(admins_set) <= sp.nat(15), "TOO_MANY_ADMINS"
+            self.data.channel_admins[channel_id] = admins_set
+
+            self.data.channel_id_counter += 1
+
+            sp.emit(
+                sp.record(
+                    channel_id=channel_id,
+                    creator=sp.sender,
+                    metadata_uri=params.metadata_uri,
+                    access_mode=params.access_mode,
+                    merkle_root=params.merkle_root,
+                    merkle_uri=params.merkle_uri,
+                    admins=params.admins,
+                    timestamp=sp.now,
+                ),
+                tag="channel_created",
+            )
+
+        @sp.entrypoint
+        def configure_channel(self, params):
+            """Set access mode and Merkle root. Creator or admin."""
+            sp.cast(params, configure_channel_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            self._check_channel_admin(params.channel_id)
+            assert not channel.hidden, "CHANNEL_HIDDEN"
+
+            self._validate_access_config(sp.record(access_mode=params.access_mode, merkle_root=params.merkle_root))
+
+            self.data.channels[params.channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=channel.metadata_uri,
+                access_mode=params.access_mode,
+                merkle_root=params.merkle_root,
+                merkle_uri=params.merkle_uri,
+                message_count=channel.message_count,
+                hidden=channel.hidden,
+                timestamp=channel.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    access_mode=params.access_mode,
+                    merkle_root=params.merkle_root,
+                    merkle_uri=params.merkle_uri,
+                    configured_by=sp.sender,
+                ),
+                tag="channel_configured",
+            )
+
+        @sp.entrypoint
+        def update_channel_admins(self, params):
+            """Add or remove channel admins. Creator only."""
+            sp.cast(params, update_channel_admins_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
+
+            # Apply removals first, then additions, so a creator can swap
+            # admins (remove one, add another) without temporarily exceeding 15.
+            for addr in params.to_remove:
+                if addr in self.data.channel_admins[params.channel_id]:
+                    self.data.channel_admins[params.channel_id].remove(addr)
+
+            for addr in params.to_add:
+                self.data.channel_admins[params.channel_id].add(addr)
+
+            assert sp.len(self.data.channel_admins[params.channel_id]) <= sp.nat(15), "TOO_MANY_ADMINS"
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    to_add=params.to_add,
+                    to_remove=params.to_remove,
+                ),
+                tag="channel_admins_updated",
+            )
+
+        @sp.entrypoint
+        def post_message(self, params):
+            """Post a message to a channel."""
+            sp.cast(params, post_message_params_type)
+            self._check_not_paused()
+
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+
+            channel = self.data.channels[params.channel_id]
+            assert not channel.hidden, "CHANNEL_HIDDEN"
+
+            # Validate parent message if replying
+            if params.parent_id.is_some():
+                parent_msg_id = params.parent_id.unwrap_some()
+                assert parent_msg_id in self.data.messages, "PARENT_NOT_FOUND"
+                parent_msg = self.data.messages[parent_msg_id]
+                assert parent_msg.channel_id == params.channel_id, "PARENT_WRONG_CHANNEL"
+
+            self._check_can_post(sp.record(channel_id=params.channel_id, proof=params.proof))
+
+            # Fee
+            assert sp.amount == self.data.message_fee, "INCORRECT_FEE"
+            self._send_fee(self.data.message_fee)
+
+            message_id = self._write_message(sp.record(channel_id=params.channel_id, content=params.content, parent_id=params.parent_id))
+
+            # Note: `content` is intentionally NOT emitted in the event so that
+            # `delete_message` actually deletes — events are part of permanent block
+            # history. Indexers should read content from the `messages` big_map.
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    message_id=message_id,
+                    sender=sp.sender,
+                    parent_id=params.parent_id,
+                    timestamp=sp.now,
+                ),
+                tag="message_posted",
+            )
+
+        @sp.entrypoint
+        def delete_message(self, message_id):
+            """Delete a message. In closed channels: sender only.
+            In unrestricted/allowlist channels: sender or channel creator."""
+            sp.cast(message_id, sp.nat)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            message = self.data.messages[message_id]
+
+            assert message.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[message.channel_id]
+
+            if channel.access_mode.is_variant.closed():
+                assert message.sender == sp.sender, "NOT_AUTHORIZED"
+            else:
+                is_sender = message.sender == sp.sender
+                is_creator = channel.creator == sp.sender
+                assert is_sender or is_creator, "NOT_AUTHORIZED"
+
+            self.data.channels[message.channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=channel.metadata_uri,
+                access_mode=channel.access_mode,
+                merkle_root=channel.merkle_root,
+                merkle_uri=channel.merkle_uri,
+                message_count=sp.as_nat(channel.message_count - 1, error="UNDERFLOW"),
+                hidden=channel.hidden,
+                timestamp=channel.timestamp,
+            )
+
+            del self.data.messages[message_id]
+
+            sp.emit(
+                sp.record(
+                    channel_id=message.channel_id,
+                    message_id=message_id,
+                    deleted_by=sp.sender,
+                ),
+                tag="message_deleted",
+            )
+
+        @sp.entrypoint
+        def update_channel(self, params):
+            """Update channel metadata. Creator or admin."""
+            sp.cast(params, sp.record(channel_id=sp.nat, metadata_uri=sp.bytes))
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            self._check_channel_admin(params.channel_id)
+            assert sp.len(params.metadata_uri) > 0, "EMPTY_METADATA"
+
+            self.data.channels[params.channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=params.metadata_uri,
+                access_mode=channel.access_mode,
+                merkle_root=channel.merkle_root,
+                merkle_uri=channel.merkle_uri,
+                message_count=channel.message_count,
+                hidden=channel.hidden,
+                timestamp=channel.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    channel_id=params.channel_id,
+                    metadata_uri=params.metadata_uri,
+                    updated_by=sp.sender,
+                ),
+                tag="channel_updated",
+            )
+
+        @sp.entrypoint
+        def hide_channel(self, channel_id):
+            """Hide a channel (soft delete). Creator only."""
+            sp.cast(channel_id, sp.nat)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[channel_id]
+            assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
+
+            self.data.channels[channel_id] = sp.record(
+                creator=channel.creator,
+                metadata_uri=channel.metadata_uri,
+                access_mode=channel.access_mode,
+                merkle_root=channel.merkle_root,
+                merkle_uri=channel.merkle_uri,
+                message_count=channel.message_count,
+                hidden=True,
+                timestamp=channel.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    channel_id=channel_id,
+                    hidden_by=sp.sender,
+                ),
+                tag="channel_hidden",
+            )
+
+        # =======================================================================
+        # Governance Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def submit_proposal(self, action):
+            """Submit a new proposal."""
+            sp.cast(action, proposal_action_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            self.data.proposals[self.data.counter] = sp.record(
+                action=action,
+                executed=False,
+                issuer=sp.sender,
+                timestamp=sp.now,
+                positive_votes=sp.nat(0),
+                negative_votes=sp.nat(0),
+            )
+            self.data.counter += 1
+
+        @sp.entrypoint
+        def vote_proposal(self, vote):
+            """Vote on an existing proposal."""
+            sp.cast(vote, vote_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert vote.proposal_id in self.data.proposals, "CHANNELS_NO_PROPOSAL"
+
+            proposal = self.data.proposals[vote.proposal_id]
+            assert not proposal.executed, "CHANNELS_ALREADY_EXECUTED"
+            self._check_not_expired(proposal.timestamp)
+
+            vote_key = (vote.proposal_id, sp.sender)
+
+            if vote_key in self.data.votes:
+                if self.data.votes[vote_key]:
+                    proposal.positive_votes = sp.as_nat(proposal.positive_votes - 1)
+                else:
+                    proposal.negative_votes = sp.as_nat(proposal.negative_votes - 1)
+
+            if vote.approval:
+                proposal.positive_votes += 1
+            else:
+                proposal.negative_votes += 1
+
+            self.data.votes[vote_key] = vote.approval
+            self.data.proposals[vote.proposal_id] = proposal
+
+        @sp.entrypoint
+        def execute_proposal(self, proposal_id):
+            """Execute an approved proposal."""
+            sp.cast(proposal_id, sp.nat)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert proposal_id in self.data.proposals, "CHANNELS_NO_PROPOSAL"
+
+            proposal = self.data.proposals[proposal_id]
+            assert not proposal.executed, "CHANNELS_ALREADY_EXECUTED"
+            minimum_votes = self._get_minimum_votes()
+            assert proposal.positive_votes >= minimum_votes, "CHANNELS_NOT_ENOUGH_VOTES"
+            self._check_not_expired(proposal.timestamp)
+
+            proposal.executed = True
+            self.data.proposals[proposal_id] = proposal
+
+            if proposal.action.is_variant.set_pause():
+                self.data.paused = proposal.action.unwrap.set_pause()
+
+            if proposal.action.is_variant.set_message_fee():
+                self.data.message_fee = proposal.action.unwrap.set_message_fee()
+
+            if proposal.action.is_variant.set_channel_fee():
+                self.data.channel_fee = proposal.action.unwrap.set_channel_fee()
+
+            if proposal.action.is_variant.set_fee_recipient():
+                self.data.fee_recipient = proposal.action.unwrap.set_fee_recipient()
+
+            if proposal.action.is_variant.update_multisig_address():
+                self.data.multisig_address = proposal.action.unwrap.update_multisig_address()
+
+            if proposal.action.is_variant.update_metadata():
+                entry = proposal.action.unwrap.update_metadata()
+                self.data.metadata[entry.key] = entry.value
+
+        # =======================================================================
+        # Views
+        # =======================================================================
+
+        @sp.onchain_view()
+        def get_channel(self, channel_id):
+            """Get channel by ID."""
+            sp.cast(channel_id, sp.nat)
+            assert channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            return self.data.channels[channel_id]
+
+        @sp.onchain_view()
+        def get_message(self, message_id):
+            """Get message by ID."""
+            sp.cast(message_id, sp.nat)
+            assert message_id in self.data.messages, "MESSAGE_NOT_FOUND"
+            return self.data.messages[message_id]
+
+        @sp.onchain_view()
+        def get_message_fee(self):
+            """Get the current message fee."""
+            return self.data.message_fee
+
+        @sp.onchain_view()
+        def get_channel_fee(self):
+            """Get the current channel creation fee."""
+            return self.data.channel_fee
+
+        @sp.onchain_view()
+        def is_channel_admin(self, params):
+            """Check if an address is a channel admin (or creator)."""
+            sp.cast(params, channel_admin_key_type)
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
+            return channel.creator == params.address or params.address in self.data.channel_admins[params.channel_id]
+
+        @sp.onchain_view()
+        def get_proposal(self, proposal_id):
+            """Get proposal by ID."""
+            sp.cast(proposal_id, sp.nat)
+            assert proposal_id in self.data.proposals, "CHANNELS_NO_PROPOSAL"
+            return self.data.proposals[proposal_id]
+
+        @sp.onchain_view()
+        def get_vote(self, key):
+            """Get vote by key (proposal_id, voter)."""
+            sp.cast(key, vote_key_type)
+            return self.data.votes.get(key, default=False)
+
+
+
+# ==============================================================================
+# Deployment Scenario
+# ==============================================================================
+
+
+
+@sp.add_test()
+def channel_deploy_shadownet():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("channel_deploy_shadownet", channels_module)
+    scenario.h1("Channel Merkle - Deployment Shadownet")
+
+    MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    MESSAGE_FEE = sp.mutez(100000)
+    CHANNEL_FEE = sp.mutez(100000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = channels_module.Channels(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        channel_fee=CHANNEL_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract

--- a/python/contracts/messages/channels.py
+++ b/python/contracts/messages/channels.py
@@ -738,7 +738,7 @@ def channel_deploy_shadownet():
 
     contract_metadata = sp.big_map(
         {
-            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+            "": sp.scenario_utils.bytes_of_string("ipfs://bafkreia2utxnnxyxwbtpb56bpfebby732h57xvzvuauai6kjvjrd6qfmxe"),
         }
     )
 

--- a/python/contracts/messages/channels.py
+++ b/python/contracts/messages/channels.py
@@ -329,7 +329,6 @@ def channels_module():
             assert sp.amount == self.data.channel_fee, "INCORRECT_FEE"
 
             self._validate_access_config(sp.record(access_mode=params.access_mode, merkle_root=params.merkle_root))
-            self._send_fee(self.data.channel_fee)
 
             channel_id = self.data.channel_id_counter
             self.data.channels[channel_id] = sp.record(
@@ -352,6 +351,8 @@ def channels_module():
             self.data.channel_admins[channel_id] = admins_set
 
             self.data.channel_id_counter += 1
+
+            self._send_fee(self.data.channel_fee)
 
             sp.emit(
                 sp.record(
@@ -552,33 +553,34 @@ def channels_module():
             )
 
         @sp.entrypoint
-        def hide_channel(self, channel_id):
-            """Hide a channel (soft delete). Creator only."""
-            sp.cast(channel_id, sp.nat)
+        def set_channel_hidden(self, params):
+            """Set a channel's hidden state (soft delete / restore). Creator only."""
+            sp.cast(params, sp.record(channel_id=sp.nat, hidden=sp.bool))
             self._check_not_paused()
             self._check_no_tez_transfer()
 
-            assert channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
-            channel = self.data.channels[channel_id]
+            assert params.channel_id in self.data.channels, "CHANNEL_NOT_FOUND"
+            channel = self.data.channels[params.channel_id]
             assert channel.creator == sp.sender, "NOT_CHANNEL_CREATOR"
 
-            self.data.channels[channel_id] = sp.record(
+            self.data.channels[params.channel_id] = sp.record(
                 creator=channel.creator,
                 metadata_uri=channel.metadata_uri,
                 access_mode=channel.access_mode,
                 merkle_root=channel.merkle_root,
                 merkle_uri=channel.merkle_uri,
                 message_count=channel.message_count,
-                hidden=True,
+                hidden=params.hidden,
                 timestamp=channel.timestamp,
             )
 
             sp.emit(
                 sp.record(
-                    channel_id=channel_id,
-                    hidden_by=sp.sender,
+                    channel_id=params.channel_id,
+                    hidden=params.hidden,
+                    updated_by=sp.sender,
                 ),
-                tag="channel_hidden",
+                tag="channel_hidden_set",
             )
 
         # =======================================================================
@@ -731,7 +733,7 @@ def channel_deploy_shadownet():
 
     MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
     FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
-    MESSAGE_FEE = sp.mutez(100000)
+    MESSAGE_FEE = sp.mutez(25000)
     CHANNEL_FEE = sp.mutez(100000)
 
     contract_metadata = sp.big_map(

--- a/python/contracts/messages/poll_comments.py
+++ b/python/contracts/messages/poll_comments.py
@@ -1,0 +1,698 @@
+import smartpy as sp
+
+
+@sp.module
+def poll_comments_module():
+    """Teia Poll Comments Contract.
+
+    Comments on off-chain teia.art polls, gated by Teia FA2 token ownership.
+    Multisig-governed moderation (hide/unhide) and parameter changes.
+
+    Error codes:
+
+    Comment:
+    - CONTRACT_PAUSED: Contract is globally paused
+    - TEZ_TRANSFER: Unexpected tez transfer
+    - INCORRECT_FEE: sp.amount does not match the required fee
+    - EMPTY_CONTENT: Comment content is empty
+    - CONTENT_TOO_LARGE: Comment content exceeds 32 KiB
+    - PARENT_NOT_FOUND: Reply target comment does not exist
+    - PARENT_WRONG_POLL: Reply target is on a different poll
+    - PARENT_HIDDEN: Reply target has been hidden
+    - COMMENT_NOT_FOUND: Comment ID does not exist
+    - NOT_AUTHORIZED: Caller cannot perform this action
+    - USER_BANNED: Caller is on the ban list (blocks post_comment and edit_comment)
+
+    Token gate / FA2:
+    - PENDING_POST_EXISTS: Another post_comment is mid-callback
+    - NO_PENDING_POST: balance_callback called with no pending comment
+    - INVALID_CALLBACK_SENDER: balance_callback sender is not the configured FA2
+    - EMPTY_BALANCE_RESPONSE: FA2 returned no balance entries
+    - NOT_TOKEN_HOLDER: Sender does not hold the configured Teia token
+    - SELF_CALLBACK_ERROR: Could not resolve self balance_callback entrypoint
+    - INVALID_FA2: Configured FA2 contract has no balance_of entrypoint
+
+    Governance (multisig-gated):
+    - POLL_VIEW_FAILED: is_user view on multisig failed
+    - POLL_NOT_MULTISIG_USER: Caller is not a multisig user
+    - POLL_GET_MIN_VOTES_FAILED: get_minimum_votes view failed
+    - POLL_GET_EXPIRATION_FAILED: get_expiration_time view failed
+    - POLL_PROPOSAL_EXPIRED: Proposal past expiration window
+    - POLL_NO_PROPOSAL: Proposal ID does not exist
+    - POLL_ALREADY_EXECUTED: Proposal already executed
+    - POLL_NOT_ENOUGH_VOTES: Positive votes below minimum
+    """
+
+    # ===========================================================================
+    # Types
+    # ===========================================================================
+
+    # --- FA2 Types (TZIP-12 standard) ---
+
+    balance_of_request_type: type = sp.record(
+        owner=sp.address,
+        token_id=sp.nat,
+    ).layout(("owner", "token_id"))
+
+    balance_of_response_type: type = sp.record(
+        request=balance_of_request_type,
+        balance=sp.nat,
+    ).layout(("request", "balance"))
+
+    balance_of_params_type: type = sp.record(
+        callback=sp.contract[sp.list[balance_of_response_type]],
+        requests=sp.list[balance_of_request_type],
+    ).layout(("requests", "callback"))
+
+    # --- Comment ---
+
+    comment_type: type = sp.record(
+        poll_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        hidden=sp.bool,
+        timestamp=sp.timestamp,
+    )
+
+    # --- Pending Post (for balance_of callback) ---
+
+    pending_comment_type: type = sp.record(
+        poll_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        fee=sp.mutez,
+    )
+
+    # --- Entrypoint Params ---
+
+    post_comment_params_type: type = sp.record(
+        poll_id=sp.nat,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+    )
+
+    edit_comment_params_type: type = sp.record(
+        comment_id=sp.nat,
+        content=sp.bytes,
+    )
+
+    set_own_comment_hidden_params_type: type = sp.record(
+        comment_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    # --- Storage Types ---
+
+    comments_map_type: type = sp.big_map[sp.nat, comment_type]
+    metadata_type: type = sp.big_map[sp.string, sp.bytes]
+
+    # --- Governance Types ---
+
+    metadata_entry_type: type = sp.record(
+        key=sp.string,
+        value=sp.bytes,
+    ).layout(("key", "value"))
+
+    token_gate_config_type: type = sp.record(
+        fa2_address=sp.address,
+        token_id=sp.nat,
+    ).layout(("fa2_address", "token_id"))
+
+    user_banned_action_type: type = sp.record(
+        address=sp.address,
+        banned=sp.bool,
+    ).layout(("address", "banned"))
+
+    proposal_action_type: type = sp.variant(
+        set_pause=sp.bool,
+        set_message_fee=sp.mutez,
+        set_fee_recipient=sp.address,
+        update_multisig_address=sp.address,
+        update_metadata=metadata_entry_type,
+        update_token_gate=token_gate_config_type,
+        set_user_banned=user_banned_action_type,
+    )
+
+    moderate_comment_hidden_params_type: type = sp.record(
+        comment_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    proposal_type: type = sp.record(
+        action=proposal_action_type,
+        executed=sp.bool,
+        issuer=sp.address,
+        timestamp=sp.timestamp,
+        positive_votes=sp.nat,
+        negative_votes=sp.nat,
+    ).layout(
+        (
+            "action",
+            (
+                "executed",
+                (
+                    "issuer",
+                    ("timestamp", ("positive_votes", "negative_votes")),
+                ),
+            ),
+        )
+    )
+
+    vote_key_type: type = sp.pair[sp.nat, sp.address]
+
+    vote_params_type: type = sp.record(
+        proposal_id=sp.nat,
+        approval=sp.bool,
+    ).layout(("proposal_id", "approval"))
+
+    # ===========================================================================
+    # Contract
+    # ===========================================================================
+
+    class PollComments(sp.Contract):
+        """Teia Poll Comments — FA2 holders can comment on off-chain polls.
+        Multisig governs moderation and parameter changes."""
+
+        def __init__(self, multisig_address, fee_recipient, message_fee, fa2_address, token_id, metadata, counter):
+            self.data.multisig_address = sp.cast(multisig_address, sp.address)
+            self.data.metadata = sp.cast(metadata, metadata_type)
+            self.data.paused = False
+            self.data.fa2_address = sp.cast(fa2_address, sp.address)
+            self.data.token_id = sp.cast(token_id, sp.nat)
+            self.data.comments = sp.cast(sp.big_map(), comments_map_type)
+            self.data.banned = sp.cast(sp.big_map(), sp.big_map[sp.address, sp.unit])
+            self.data.pending_comment = sp.cast(None, sp.option[pending_comment_type])
+            self.data.comment_id_counter = sp.nat(1)
+            self.data.message_fee = sp.cast(message_fee, sp.mutez)
+            self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
+            self.data.proposals = sp.cast(sp.big_map(), sp.big_map[sp.nat, proposal_type])
+            self.data.votes = sp.cast(sp.big_map(), sp.big_map[vote_key_type, sp.bool])
+            self.data.counter = sp.cast(counter, sp.nat)
+
+        # =======================================================================
+        # Private Helpers
+        # =======================================================================
+
+        @sp.private(with_storage="read-only")
+        def _check_not_paused(self):
+            assert not self.data.paused, "CONTRACT_PAUSED"
+
+        @sp.private(with_storage="read-only")
+        def _check_no_tez_transfer(self):
+            assert sp.amount == sp.tez(0), "TEZ_TRANSFER"
+
+        @sp.private(with_storage="read-only")
+        def _check_not_banned(self):
+            assert not (sp.sender in self.data.banned), "USER_BANNED"
+
+        @sp.private(with_storage="read-only")
+        def _check_is_user(self):
+            is_user = sp.view(
+                "is_user",
+                self.data.multisig_address,
+                sp.sender,
+                sp.bool,
+            ).unwrap_some(error="POLL_VIEW_FAILED")
+            assert is_user, "POLL_NOT_MULTISIG_USER"
+
+        @sp.private(with_storage="read-only")
+        def _get_minimum_votes(self):
+            return sp.view(
+                "get_minimum_votes",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="POLL_GET_MIN_VOTES_FAILED")
+
+        @sp.private(with_storage="read-only")
+        def _check_not_expired(self, timestamp):
+            expiration_days = sp.view(
+                "get_expiration_time",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="POLL_GET_EXPIRATION_FAILED")
+
+            expiration_seconds = sp.to_int(expiration_days * 86400)
+            expiration_time = sp.add_seconds(timestamp, expiration_seconds)
+            assert not (sp.now > expiration_time), "POLL_PROPOSAL_EXPIRED"
+
+        @sp.private(with_storage="read-write", with_operations=True)
+        def _send_fee(self, fee):
+            """Sends fee to fee_recipient if > 0."""
+            if fee > sp.mutez(0):
+                sp.send(self.data.fee_recipient, fee)
+
+        # =======================================================================
+        # Comment Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def post_comment(self, params):
+            """Post a comment on a poll. Initiates FA2 balance check."""
+            sp.cast(params, post_comment_params_type)
+            self._check_not_paused()
+            self._check_not_banned()
+
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+            assert not self.data.pending_comment.is_some(), "PENDING_POST_EXISTS"
+
+            assert sp.amount == self.data.message_fee, "INCORRECT_FEE"
+
+            # Validate parent comment if replying
+            if params.parent_id.is_some():
+                parent_comment_id = params.parent_id.unwrap_some()
+                assert parent_comment_id in self.data.comments, "PARENT_NOT_FOUND"
+                parent_comment = self.data.comments[parent_comment_id]
+                assert parent_comment.poll_id == params.poll_id, "PARENT_WRONG_POLL"
+                assert not parent_comment.hidden, "PARENT_HIDDEN"
+
+            self.data.pending_comment = sp.Some(sp.record(
+                poll_id=params.poll_id,
+                sender=sp.sender,
+                content=params.content,
+                parent_id=params.parent_id,
+                fee=sp.amount,
+            ))
+
+            callback = sp.contract(
+                sp.list[balance_of_response_type],
+                sp.self_address,
+                entrypoint="balance_callback",
+            ).unwrap_some(error="SELF_CALLBACK_ERROR")
+
+            fa2_handle = sp.contract(
+                balance_of_params_type,
+                self.data.fa2_address,
+                entrypoint="balance_of",
+            ).unwrap_some(error="INVALID_FA2")
+
+            sp.transfer(
+                sp.record(
+                    requests=[sp.record(owner=sp.sender, token_id=self.data.token_id)],
+                    callback=callback,
+                ),
+                sp.tez(0),
+                fa2_handle,
+            )
+
+        @sp.entrypoint
+        def balance_callback(self, responses):
+            """Callback from FA2 balance_of. Writes comment if balance > 0."""
+            sp.cast(responses, sp.list[balance_of_response_type])
+
+            pending = self.data.pending_comment.unwrap_some(error="NO_PENDING_POST")
+
+            # Caller must be the configured FA2 contract
+            assert sp.sender == self.data.fa2_address, "INVALID_CALLBACK_SENDER"
+
+            assert sp.len(responses) > 0, "EMPTY_BALANCE_RESPONSE"
+            found_balance = sp.nat(0)
+            for response in responses:
+                if response.request.owner == pending.sender:
+                    if response.request.token_id == self.data.token_id:
+                        found_balance = response.balance
+            assert found_balance > 0, "NOT_TOKEN_HOLDER"
+
+            comment_id = self.data.comment_id_counter
+            self.data.comments[comment_id] = sp.record(
+                poll_id=pending.poll_id,
+                sender=pending.sender,
+                content=pending.content,
+                parent_id=pending.parent_id,
+                hidden=False,
+                timestamp=sp.now,
+            )
+
+            self.data.comment_id_counter += 1
+
+            self._send_fee(pending.fee)
+
+            # Note: `content` is intentionally NOT emitted in the event so that
+            # `edit_comment` and hide moderation are meaningful — events are part
+            # of permanent block history. Indexers should read content from the
+            # `comments` big_map.
+            sp.emit(
+                sp.record(
+                    poll_id=pending.poll_id,
+                    comment_id=comment_id,
+                    sender=pending.sender,
+                    parent_id=pending.parent_id,
+                    timestamp=sp.now,
+                ),
+                tag="comment_posted",
+            )
+
+            self.data.pending_comment = None
+
+        @sp.entrypoint
+        def edit_comment(self, params):
+            """Edit a comment. Sender only. Overwrites content in place."""
+            sp.cast(params, edit_comment_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_not_banned()
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+            assert comment.sender == sp.sender, "NOT_AUTHORIZED"
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+
+            self.data.comments[params.comment_id] = sp.record(
+                poll_id=comment.poll_id,
+                sender=comment.sender,
+                content=params.content,
+                parent_id=comment.parent_id,
+                hidden=comment.hidden,
+                timestamp=comment.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    comment_id=params.comment_id,
+                    sender=sp.sender,
+                ),
+                tag="comment_edited",
+            )
+
+        @sp.entrypoint
+        def set_own_comment_hidden(self, params):
+            """Toggle hidden flag on caller's own comment."""
+            sp.cast(params, set_own_comment_hidden_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+            assert comment.sender == sp.sender, "NOT_AUTHORIZED"
+
+            self.data.comments[params.comment_id] = sp.record(
+                poll_id=comment.poll_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                hidden=params.hidden,
+                timestamp=comment.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    comment_id=params.comment_id,
+                    hidden=params.hidden,
+                    updated_by=sp.sender,
+                ),
+                tag="comment_hidden_set",
+            )
+
+        @sp.entrypoint
+        def moderate_comment_hidden(self, params):
+            """Hide or unhide any comment. Any multisig user, no vote required."""
+            sp.cast(params, moderate_comment_hidden_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+
+            self.data.comments[params.comment_id] = sp.record(
+                poll_id=comment.poll_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                hidden=params.hidden,
+                timestamp=comment.timestamp,
+            )
+
+            sp.emit(
+                sp.record(
+                    comment_id=params.comment_id,
+                    hidden=params.hidden,
+                    moderator=sp.sender,
+                ),
+                tag="comment_moderated",
+            )
+
+        # =======================================================================
+        # Governance Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def submit_proposal(self, action):
+            """Submit a new proposal."""
+            sp.cast(action, proposal_action_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            self.data.proposals[self.data.counter] = sp.record(
+                action=action,
+                executed=False,
+                issuer=sp.sender,
+                timestamp=sp.now,
+                positive_votes=sp.nat(0),
+                negative_votes=sp.nat(0),
+            )
+            self.data.counter += 1
+
+        @sp.entrypoint
+        def vote_proposal(self, vote):
+            """Vote on an existing proposal."""
+            sp.cast(vote, vote_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert vote.proposal_id in self.data.proposals, "POLL_NO_PROPOSAL"
+
+            proposal = self.data.proposals[vote.proposal_id]
+            assert not proposal.executed, "POLL_ALREADY_EXECUTED"
+            self._check_not_expired(proposal.timestamp)
+
+            vote_key = (vote.proposal_id, sp.sender)
+
+            if vote_key in self.data.votes:
+                if self.data.votes[vote_key]:
+                    proposal.positive_votes = sp.as_nat(proposal.positive_votes - 1)
+                else:
+                    proposal.negative_votes = sp.as_nat(proposal.negative_votes - 1)
+
+            if vote.approval:
+                proposal.positive_votes += 1
+            else:
+                proposal.negative_votes += 1
+
+            self.data.votes[vote_key] = vote.approval
+            self.data.proposals[vote.proposal_id] = proposal
+
+        @sp.entrypoint
+        def execute_proposal(self, proposal_id):
+            """Execute an approved proposal."""
+            sp.cast(proposal_id, sp.nat)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert proposal_id in self.data.proposals, "POLL_NO_PROPOSAL"
+
+            proposal = self.data.proposals[proposal_id]
+            assert not proposal.executed, "POLL_ALREADY_EXECUTED"
+            minimum_votes = self._get_minimum_votes()
+            assert proposal.positive_votes >= minimum_votes, "POLL_NOT_ENOUGH_VOTES"
+            self._check_not_expired(proposal.timestamp)
+
+            proposal.executed = True
+            self.data.proposals[proposal_id] = proposal
+
+            if proposal.action.is_variant.set_pause():
+                self.data.paused = proposal.action.unwrap.set_pause()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        paused=self.data.paused,
+                        updated_by=sp.sender,
+                    ),
+                    tag="pause_set",
+                )
+
+            if proposal.action.is_variant.set_message_fee():
+                self.data.message_fee = proposal.action.unwrap.set_message_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        message_fee=self.data.message_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="message_fee_set",
+                )
+
+            if proposal.action.is_variant.set_fee_recipient():
+                self.data.fee_recipient = proposal.action.unwrap.set_fee_recipient()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        fee_recipient=self.data.fee_recipient,
+                        updated_by=sp.sender,
+                    ),
+                    tag="fee_recipient_set",
+                )
+
+            if proposal.action.is_variant.update_multisig_address():
+                self.data.multisig_address = proposal.action.unwrap.update_multisig_address()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        multisig_address=self.data.multisig_address,
+                        updated_by=sp.sender,
+                    ),
+                    tag="multisig_address_set",
+                )
+
+            if proposal.action.is_variant.update_metadata():
+                entry = proposal.action.unwrap.update_metadata()
+                self.data.metadata[entry.key] = entry.value
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        key=entry.key,
+                        updated_by=sp.sender,
+                    ),
+                    tag="metadata_updated",
+                )
+
+            if proposal.action.is_variant.update_token_gate():
+                cfg = proposal.action.unwrap.update_token_gate()
+                self.data.fa2_address = cfg.fa2_address
+                self.data.token_id = cfg.token_id
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        fa2_address=cfg.fa2_address,
+                        token_id=cfg.token_id,
+                        updated_by=sp.sender,
+                    ),
+                    tag="token_gate_updated",
+                )
+
+            if proposal.action.is_variant.set_user_banned():
+                ban = proposal.action.unwrap.set_user_banned()
+                if ban.banned:
+                    self.data.banned[ban.address] = ()
+                else:
+                    if ban.address in self.data.banned:
+                        del self.data.banned[ban.address]
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        address=ban.address,
+                        banned=ban.banned,
+                        updated_by=sp.sender,
+                    ),
+                    tag="user_banned_set",
+                )
+
+        # =======================================================================
+        # Views
+        # =======================================================================
+
+        @sp.onchain_view()
+        def get_comment(self, comment_id):
+            """Get comment by ID."""
+            sp.cast(comment_id, sp.nat)
+            assert comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            return self.data.comments[comment_id]
+
+        @sp.onchain_view()
+        def get_message_fee(self):
+            """Get the current message fee."""
+            return self.data.message_fee
+
+        @sp.onchain_view()
+        def get_token_gate(self):
+            """Get the configured Teia FA2 contract and token_id."""
+            return sp.record(
+                fa2_address=self.data.fa2_address,
+                token_id=self.data.token_id,
+            )
+
+        @sp.onchain_view()
+        def get_proposal(self, proposal_id):
+            """Get proposal by ID."""
+            sp.cast(proposal_id, sp.nat)
+            assert proposal_id in self.data.proposals, "POLL_NO_PROPOSAL"
+            return self.data.proposals[proposal_id]
+
+        @sp.onchain_view()
+        def get_vote(self, key):
+            """Get vote by key (proposal_id, voter)."""
+            sp.cast(key, vote_key_type)
+            return self.data.votes.get(key, default=False)
+
+        @sp.onchain_view()
+        def is_banned(self, address):
+            """Check if an address is on the ban list."""
+            sp.cast(address, sp.address)
+            return address in self.data.banned
+
+
+# ==============================================================================
+# Deployment Scenario
+# ==============================================================================
+
+
+@sp.add_test()
+def poll_comments_deploy_shadownet():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("poll_comments_deploy_shadownet", poll_comments_module)
+    scenario.h1("Poll Comments - Deployment Shadownet")
+
+    MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    TEIA_FA2_ADDRESS = sp.address("KT1RHCCYWKDwMzmTZq7kG7H3brHAno3yfMQD")
+    TEIA_TOKEN_ID = sp.nat(0)
+    MESSAGE_FEE = sp.mutez(25000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = poll_comments_module.PollComments(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        fa2_address=TEIA_FA2_ADDRESS,
+        token_id=TEIA_TOKEN_ID,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+
+@sp.add_test()
+def poll_comments_deploy_mainnet():
+    """Deployment scenario for Tezos mainnet."""
+    scenario = sp.test_scenario("poll_comments_deploy_mainnet", poll_comments_module)
+    scenario.h1("Poll Comments - Deployment Mainnet")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    TEIA_FA2_ADDRESS = sp.address("KT1QrtA753MSv8VGxkDrKKyJniG5JtuHHbtV")
+    TEIA_TOKEN_ID = sp.nat(0)
+    MESSAGE_FEE = sp.mutez(25000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmXfrEZmN6spvdoqrHvF6ZfhTrL8zfCSJ5nhc2drrn6Rm8"),
+        }
+    )
+
+    contract = poll_comments_module.PollComments(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        fa2_address=TEIA_FA2_ADDRESS,
+        token_id=TEIA_TOKEN_ID,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract

--- a/python/contracts/messages/poll_comments.py
+++ b/python/contracts/messages/poll_comments.py
@@ -13,7 +13,9 @@ def poll_comments_module():
     Comment:
     - CONTRACT_PAUSED: Contract is globally paused
     - TEZ_TRANSFER: Unexpected tez transfer
-    - INCORRECT_FEE: sp.amount does not match the required fee
+    - INCORRECT_FEE: sp.amount does not match the required fee for the action
+      (post_fee for post_comment, edit_fee for edit_comment, hide_fee for
+      set_own_comment_hidden)
     - EMPTY_CONTENT: Comment content is empty
     - CONTENT_TOO_LARGE: Comment content exceeds 32 KiB
     - PARENT_NOT_FOUND: Reply target comment does not exist
@@ -22,6 +24,7 @@ def poll_comments_module():
     - COMMENT_NOT_FOUND: Comment ID does not exist
     - NOT_AUTHORIZED: Caller cannot perform this action
     - USER_BANNED: Caller is on the ban list (blocks post_comment and edit_comment)
+    - VERSION_NOT_FOUND: Requested historical version of a comment does not exist
 
     Token gate / FA2:
     - PENDING_POST_EXISTS: Another post_comment is mid-callback
@@ -73,7 +76,24 @@ def poll_comments_module():
         parent_id=sp.option[sp.nat],
         hidden=sp.bool,
         timestamp=sp.timestamp,
+        version=sp.nat,
     )
+
+    # --- Comment History ---
+    # Snapshot of a prior version of a comment. 
+    # The live version lives in `comments`; `comment_history[(comment_id, n)]` holds the n-th archived
+    # version. Versions start at 1; archived indices 1..comment.version-1 are
+    # populated (empty for never-edited comments at version=1).
+
+    history_entry_type: type = sp.record(
+        poll_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        timestamp=sp.timestamp,
+    )
+
+    history_key_type: type = sp.pair[sp.nat, sp.nat]
 
     # --- Pending Post (for balance_of callback) ---
 
@@ -127,7 +147,9 @@ def poll_comments_module():
 
     proposal_action_type: type = sp.variant(
         set_pause=sp.bool,
-        set_message_fee=sp.mutez,
+        set_post_fee=sp.mutez,
+        set_edit_fee=sp.mutez,
+        set_hide_fee=sp.mutez,
         set_fee_recipient=sp.address,
         update_multisig_address=sp.address,
         update_metadata=metadata_entry_type,
@@ -175,17 +197,20 @@ def poll_comments_module():
         """Teia Poll Comments — FA2 holders can comment on off-chain polls.
         Multisig governs moderation and parameter changes."""
 
-        def __init__(self, multisig_address, fee_recipient, message_fee, fa2_address, token_id, metadata, counter):
+        def __init__(self, multisig_address, fee_recipient, post_fee, edit_fee, hide_fee, fa2_address, token_id, metadata, counter):
             self.data.multisig_address = sp.cast(multisig_address, sp.address)
             self.data.metadata = sp.cast(metadata, metadata_type)
             self.data.paused = False
             self.data.fa2_address = sp.cast(fa2_address, sp.address)
             self.data.token_id = sp.cast(token_id, sp.nat)
             self.data.comments = sp.cast(sp.big_map(), comments_map_type)
+            self.data.comment_history = sp.cast(sp.big_map(), sp.big_map[history_key_type, history_entry_type])
             self.data.banned = sp.cast(sp.big_map(), sp.big_map[sp.address, sp.unit])
             self.data.pending_comment = sp.cast(None, sp.option[pending_comment_type])
             self.data.comment_id_counter = sp.nat(1)
-            self.data.message_fee = sp.cast(message_fee, sp.mutez)
+            self.data.post_fee = sp.cast(post_fee, sp.mutez)
+            self.data.edit_fee = sp.cast(edit_fee, sp.mutez)
+            self.data.hide_fee = sp.cast(hide_fee, sp.mutez)
             self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
             self.data.proposals = sp.cast(sp.big_map(), sp.big_map[sp.nat, proposal_type])
             self.data.votes = sp.cast(sp.big_map(), sp.big_map[vote_key_type, sp.bool])
@@ -260,7 +285,7 @@ def poll_comments_module():
             assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
             assert not self.data.pending_comment.is_some(), "PENDING_POST_EXISTS"
 
-            assert sp.amount == self.data.message_fee, "INCORRECT_FEE"
+            assert sp.amount == self.data.post_fee, "INCORRECT_FEE"
 
             # Validate parent comment if replying
             if params.parent_id.is_some():
@@ -325,16 +350,14 @@ def poll_comments_module():
                 parent_id=pending.parent_id,
                 hidden=False,
                 timestamp=sp.now,
+                version=sp.nat(1),
             )
 
             self.data.comment_id_counter += 1
 
             self._send_fee(pending.fee)
 
-            # Note: `content` is intentionally NOT emitted in the event so that
-            # `edit_comment` and hide moderation are meaningful — events are part
-            # of permanent block history. Indexers should read content from the
-            # `comments` big_map.
+            # Note: `content` is intentionally NOT emitted in the event
             sp.emit(
                 sp.record(
                     poll_id=pending.poll_id,
@@ -350,11 +373,13 @@ def poll_comments_module():
 
         @sp.entrypoint
         def edit_comment(self, params):
-            """Edit a comment. Sender only. Overwrites content in place."""
+            """Edit a comment. Sender only. Archives the current version into
+            comment_history before overwriting content."""
             sp.cast(params, edit_comment_params_type)
             self._check_not_paused()
-            self._check_no_tez_transfer()
             self._check_not_banned()
+
+            assert sp.amount == self.data.edit_fee, "INCORRECT_FEE"
 
             assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
             comment = self.data.comments[params.comment_id]
@@ -362,19 +387,35 @@ def poll_comments_module():
             assert sp.len(params.content) > 0, "EMPTY_CONTENT"
             assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
 
+            self.data.comment_history[(params.comment_id, comment.version)] = sp.record(
+                poll_id=comment.poll_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                timestamp=comment.timestamp,
+            )
+
+            new_version = comment.version + 1
             self.data.comments[params.comment_id] = sp.record(
                 poll_id=comment.poll_id,
                 sender=comment.sender,
                 content=params.content,
                 parent_id=comment.parent_id,
                 hidden=comment.hidden,
-                timestamp=comment.timestamp,
+                timestamp=sp.now,
+                version=new_version,
             )
+
+            self._send_fee(sp.amount)
 
             sp.emit(
                 sp.record(
+                    poll_id=comment.poll_id,
                     comment_id=params.comment_id,
-                    sender=sp.sender,
+                    sender=comment.sender,
+                    parent_id=comment.parent_id,
+                    timestamp=sp.now,
+                    version=new_version,
                 ),
                 tag="comment_edited",
             )
@@ -384,7 +425,8 @@ def poll_comments_module():
             """Toggle hidden flag on caller's own comment."""
             sp.cast(params, set_own_comment_hidden_params_type)
             self._check_not_paused()
-            self._check_no_tez_transfer()
+
+            assert sp.amount == self.data.hide_fee, "INCORRECT_FEE"
 
             assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
             comment = self.data.comments[params.comment_id]
@@ -397,7 +439,10 @@ def poll_comments_module():
                 parent_id=comment.parent_id,
                 hidden=params.hidden,
                 timestamp=comment.timestamp,
+                version=comment.version,
             )
+
+            self._send_fee(sp.amount)
 
             sp.emit(
                 sp.record(
@@ -425,6 +470,7 @@ def poll_comments_module():
                 parent_id=comment.parent_id,
                 hidden=params.hidden,
                 timestamp=comment.timestamp,
+                version=comment.version,
             )
 
             sp.emit(
@@ -513,15 +559,37 @@ def poll_comments_module():
                     tag="pause_set",
                 )
 
-            if proposal.action.is_variant.set_message_fee():
-                self.data.message_fee = proposal.action.unwrap.set_message_fee()
+            if proposal.action.is_variant.set_post_fee():
+                self.data.post_fee = proposal.action.unwrap.set_post_fee()
                 sp.emit(
                     sp.record(
                         proposal_id=proposal_id,
-                        message_fee=self.data.message_fee,
+                        post_fee=self.data.post_fee,
                         updated_by=sp.sender,
                     ),
-                    tag="message_fee_set",
+                    tag="post_fee_set",
+                )
+
+            if proposal.action.is_variant.set_edit_fee():
+                self.data.edit_fee = proposal.action.unwrap.set_edit_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        edit_fee=self.data.edit_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="edit_fee_set",
+                )
+
+            if proposal.action.is_variant.set_hide_fee():
+                self.data.hide_fee = proposal.action.unwrap.set_hide_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        hide_fee=self.data.hide_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="hide_fee_set",
                 )
 
             if proposal.action.is_variant.set_fee_recipient():
@@ -601,9 +669,35 @@ def poll_comments_module():
             return self.data.comments[comment_id]
 
         @sp.onchain_view()
-        def get_message_fee(self):
-            """Get the current message fee."""
-            return self.data.message_fee
+        def get_comment_version(self, key):
+            """Get an archived version of a comment.
+
+            `key` is `(comment_id, version)`. Returns the snapshot of the
+            comment at that version. Live state lives in `comments`."""
+            sp.cast(key, history_key_type)
+            assert key in self.data.comment_history, "VERSION_NOT_FOUND"
+            return self.data.comment_history[key]
+
+        @sp.onchain_view()
+        def get_comment_version_count(self, comment_id):
+            """Get the total version count for a comment.
+
+            Versions start at 1, so this returns 1 for a never-edited comment
+            and `1 + number_of_edits` otherwise. Archived snapshots exist at
+            `comment_history[(comment_id, 1..version-1)]`; the live version
+            (index = `version`) lives in `comments[comment_id]`."""
+            sp.cast(comment_id, sp.nat)
+            assert comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            return self.data.comments[comment_id].version
+
+        @sp.onchain_view()
+        def get_fees(self):
+            """Get the current post/edit/hide fees."""
+            return sp.record(
+                post_fee=self.data.post_fee,
+                edit_fee=self.data.edit_fee,
+                hide_fee=self.data.hide_fee,
+            )
 
         @sp.onchain_view()
         def get_token_gate(self):
@@ -646,20 +740,24 @@ def poll_comments_deploy_shadownet():
 
     MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
     FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
-    TEIA_FA2_ADDRESS = sp.address("KT1RHCCYWKDwMzmTZq7kG7H3brHAno3yfMQD")
+    TEIA_FA2_ADDRESS = sp.address("KT1LHXjgnURrnCybZ26mEQM3RQ2tLbpZwmi6")
     TEIA_TOKEN_ID = sp.nat(0)
-    MESSAGE_FEE = sp.mutez(25000)
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
 
     contract_metadata = sp.big_map(
         {
-            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmSCqrL2xj3W6brABirVVSEX1drjrc3WPCFf681zSkwFi9"),
         }
     )
 
     contract = poll_comments_module.PollComments(
         multisig_address=MULTISIG_ADDRESS,
         fee_recipient=FEE_RECIPIENT_ADDRESS,
-        message_fee=MESSAGE_FEE,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
         fa2_address=TEIA_FA2_ADDRESS,
         token_id=TEIA_TOKEN_ID,
         metadata=contract_metadata,
@@ -678,18 +776,22 @@ def poll_comments_deploy_mainnet():
     FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
     TEIA_FA2_ADDRESS = sp.address("KT1QrtA753MSv8VGxkDrKKyJniG5JtuHHbtV")
     TEIA_TOKEN_ID = sp.nat(0)
-    MESSAGE_FEE = sp.mutez(25000)
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
 
     contract_metadata = sp.big_map(
         {
-            "": sp.scenario_utils.bytes_of_string("ipfs://QmXfrEZmN6spvdoqrHvF6ZfhTrL8zfCSJ5nhc2drrn6Rm8"),
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmSCqrL2xj3W6brABirVVSEX1drjrc3WPCFf681zSkwFi9"),
         }
     )
 
     contract = poll_comments_module.PollComments(
         multisig_address=MULTISIG_ADDRESS,
         fee_recipient=FEE_RECIPIENT_ADDRESS,
-        message_fee=MESSAGE_FEE,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
         fa2_address=TEIA_FA2_ADDRESS,
         token_id=TEIA_TOKEN_ID,
         metadata=contract_metadata,

--- a/python/contracts/messages/tests.py
+++ b/python/contracts/messages/tests.py
@@ -1,0 +1,1893 @@
+
+# --- Test: Create conversation and post ---
+
+@sp.add_test()
+def test_create_and_post():
+    """Test creating a conversation and posting messages."""
+    scenario = sp.test_scenario("create_and_post", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Create Conversation and Post")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    # Alice creates a conversation with Bob
+    scenario.h2("Alice creates conversation with Bob")
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+    )
+    scenario.verify(contract.data.conversations[1].creator == alice.address)
+    scenario.verify(contract.data.conversations[1].message_count == 0)
+
+    # Alice is a participant
+    is_alice = sp.View(contract, "is_participant")(
+        sp.record(conversation_id=sp.nat(1), address=alice.address)
+    )
+    scenario.verify(is_alice)
+
+    # Bob is a participant
+    is_bob = sp.View(contract, "is_participant")(
+        sp.record(conversation_id=sp.nat(1), address=bob.address)
+    )
+    scenario.verify(is_bob)
+
+    # Charlie is NOT a participant
+    is_charlie = sp.View(contract, "is_participant")(
+        sp.record(conversation_id=sp.nat(1), address=charlie.address)
+    )
+    scenario.verify(~is_charlie)
+
+    # Alice posts
+    scenario.h2("Alice posts")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x48656c6c6f"), parent_id=sp.none),
+        _sender=alice,
+    )
+    scenario.verify(contract.data.messages[1].sender == alice.address)
+
+    # Bob posts
+    scenario.h2("Bob posts")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x576f726c64"), parent_id=sp.none),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[2].sender == bob.address)
+
+    conv = sp.View(contract, "get_conversation")(sp.nat(1))
+    scenario.verify(conv.message_count == 2)
+
+    # Charlie cannot post (not a participant)
+    scenario.h2("Charlie rejected — not participant")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4e6f7065"), parent_id=sp.none),
+        _sender=charlie,
+        _valid=False,
+        _exception="NOT_PARTICIPANT",
+    )
+
+
+# --- Test: Participants management ---
+
+@sp.add_test()
+def test_participants():
+    """Test adding and removing participants."""
+    scenario = sp.test_scenario("participants", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Participants Management")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+    )
+
+    # Non-admin cannot add participants
+    scenario.h2("Non-admin cannot update participants")
+    contract.update_participants(
+        sp.record(conversation_id=sp.nat(1), to_add=[charlie.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CONVERSATION_ADMIN",
+    )
+
+    # Creator adds charlie
+    scenario.h2("Creator adds Charlie")
+    contract.update_participants(
+        sp.record(conversation_id=sp.nat(1), to_add=[charlie.address], to_remove=[]),
+        _sender=alice,
+    )
+
+    # Charlie can now post
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=charlie,
+    )
+    scenario.verify(contract.data.messages[1].sender == charlie.address)
+
+    # Creator removes Bob
+    scenario.h2("Creator removes Bob")
+    contract.update_participants(
+        sp.record(conversation_id=sp.nat(1), to_add=[], to_remove=[bob.address]),
+        _sender=alice,
+    )
+
+    # Bob can no longer post
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4e6f7065"), parent_id=sp.none),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_PARTICIPANT",
+    )
+
+
+# --- Test: Conversation admins ---
+
+@sp.add_test()
+def test_conversation_admins():
+    """Test admin delegation for conversations."""
+    scenario = sp.test_scenario("conversation_admins", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Conversation Admins")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address, charlie.address]),
+        _sender=alice,
+    )
+
+    # Only creator can add admins
+    scenario.h2("Non-creator cannot add admins")
+    contract.update_conversation_admins(
+        sp.record(conversation_id=sp.nat(1), to_add=[bob.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CONVERSATION_CREATOR",
+    )
+
+    # Creator adds Bob as admin
+    scenario.h2("Creator adds Bob as admin")
+    contract.update_conversation_admins(
+        sp.record(conversation_id=sp.nat(1), to_add=[bob.address], to_remove=[]),
+        _sender=alice,
+    )
+
+    is_admin = sp.View(contract, "is_conversation_admin")(
+        sp.record(conversation_id=sp.nat(1), address=bob.address)
+    )
+    scenario.verify(is_admin)
+
+    # Admin can add participants
+    scenario.h2("Admin adds Dave")
+    contract.update_participants(
+        sp.record(conversation_id=sp.nat(1), to_add=[dave.address], to_remove=[]),
+        _sender=bob,
+    )
+
+    is_dave = sp.View(contract, "is_participant")(
+        sp.record(conversation_id=sp.nat(1), address=dave.address)
+    )
+    scenario.verify(is_dave)
+
+    # Admin can delete messages
+    scenario.h2("Admin deletes message")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=charlie,
+    )
+    contract.delete_message(sp.nat(1), _sender=bob)
+    scenario.verify(~contract.data.messages.contains(sp.nat(1)))
+
+    # Admin cannot add other admins
+    scenario.h2("Admin cannot add other admins")
+    contract.update_conversation_admins(
+        sp.record(conversation_id=sp.nat(1), to_add=[charlie.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CONVERSATION_CREATOR",
+    )
+
+    # Admin cannot delete conversation
+    scenario.h2("Admin cannot delete conversation")
+    contract.delete_conversation(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_CONVERSATION_CREATOR")
+
+    # Creator removes admin
+    scenario.h2("Creator removes Bob as admin")
+    contract.update_conversation_admins(
+        sp.record(conversation_id=sp.nat(1), to_add=[], to_remove=[bob.address]),
+        _sender=alice,
+    )
+
+    # Bob can no longer update participants
+    contract.update_participants(
+        sp.record(conversation_id=sp.nat(1), to_add=[admin.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CONVERSATION_ADMIN",
+    )
+
+
+# --- Test: Message replies ---
+
+@sp.add_test()
+def test_replies():
+    """Test message reply functionality."""
+    scenario = sp.test_scenario("dm_replies", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Message Replies")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+    )
+
+    # Top-level message
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x48656c6c6f"), parent_id=sp.none),
+        _sender=alice,
+    )
+    scenario.verify(~contract.data.messages[1].parent_id.is_some())
+
+    # Reply
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x5265706c79"), parent_id=sp.Some(sp.nat(1))),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[2].parent_id.is_some())
+
+    # Reply to non-existent message
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4e6f"), parent_id=sp.Some(sp.nat(999))),
+        _sender=alice,
+        _valid=False,
+        _exception="PARENT_NOT_FOUND",
+    )
+
+    # Reply to message in different conversation
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d65746132"), participants=[bob.address]),
+        _sender=alice,
+    )
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(2), content=sp.bytes("0x4e6f"), parent_id=sp.Some(sp.nat(1))),
+        _sender=alice,
+        _valid=False,
+        _exception="PARENT_WRONG_CONVERSATION",
+    )
+
+    # Delete parent, reply remains
+    contract.delete_message(sp.nat(1), _sender=alice)
+    scenario.verify(~contract.data.messages.contains(sp.nat(1)))
+    scenario.verify(contract.data.messages[2].sender == bob.address)
+
+
+# --- Test: Delete conversation ---
+
+@sp.add_test()
+def test_delete_conversation():
+    """Test deleting a conversation."""
+    scenario = sp.test_scenario("delete_conversation", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Delete Conversation")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+    )
+
+    # Non-creator cannot delete
+    contract.delete_conversation(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_CONVERSATION_CREATOR")
+
+    # Creator deletes
+    contract.delete_conversation(sp.nat(1), _sender=alice)
+    scenario.verify(~contract.data.conversations.contains(sp.nat(1)))
+
+
+# --- Test: Fees ---
+
+@sp.add_test()
+def test_fees():
+    """Test message and conversation fees."""
+    scenario = sp.test_scenario("dm_fees", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Fees")
+
+    admin = sp.test_account("Admin")
+    alice = sp.test_account("Alice")
+    bob = sp.test_account("Bob")
+
+    multisig = mock_multisig_module.MockMultisig(
+        users={admin.address},
+        minimum_votes=sp.nat(1),
+        expiration_time=sp.nat(30),
+    )
+    scenario += multisig
+
+    contract_metadata = sp.big_map({"": sp.scenario_utils.bytes_of_string("ipfs://test")})
+    contract = direct_messages_module.DirectMessages(
+        multisig_address=multisig.address,
+        fee_recipient=admin.address,
+        message_fee=sp.mutez(100),
+        conversation_fee=sp.mutez(500),
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+    # Wrong conversation fee
+    scenario.h2("Wrong conversation fee")
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+        _amount=sp.mutez(0),
+        _valid=False,
+        _exception="INCORRECT_FEE",
+    )
+
+    # Correct conversation fee
+    scenario.h2("Correct conversation fee")
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+        _amount=sp.mutez(500),
+    )
+
+    # Wrong message fee
+    scenario.h2("Wrong message fee")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+        _amount=sp.mutez(0),
+        _valid=False,
+        _exception="INCORRECT_FEE",
+    )
+
+    # Correct message fee
+    scenario.h2("Correct message fee")
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+        _amount=sp.mutez(100),
+    )
+
+
+# --- Test: Edge cases ---
+
+@sp.add_test()
+def test_edge_cases():
+    """Test edge cases and error handling."""
+    scenario = sp.test_scenario("dm_edge_cases", [mock_multisig_module, direct_messages_module])
+    scenario.h1("Edge Cases")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x6d657461"), participants=[bob.address]),
+        _sender=alice,
+    )
+
+    # Empty content
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(1), content=sp.bytes("0x"), parent_id=sp.none),
+        _sender=alice,
+        _valid=False,
+        _exception="EMPTY_CONTENT",
+    )
+
+    # Non-existent conversation
+    contract.post_message(
+        sp.record(conversation_id=sp.nat(999), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+        _valid=False,
+        _exception="CONVERSATION_NOT_FOUND",
+    )
+
+    # Empty metadata
+    contract.create_conversation(
+        sp.record(metadata_uri=sp.bytes("0x"), participants=[bob.address]),
+        _sender=alice,
+        _valid=False,
+        _exception="EMPTY_METADATA",
+    )
+
+    # Delete non-existent message
+    contract.delete_message(sp.nat(999), _sender=alice, _valid=False, _exception="MESSAGE_NOT_FOUND")
+
+    # Delete non-existent conversation
+    contract.delete_conversation(sp.nat(999), _sender=alice, _valid=False, _exception="CONVERSATION_NOT_FOUND")
+
+
+
+@sp.add_test()
+def deploy():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("deploy", direct_messages_module)
+    scenario.h1("Direct Messages - Deployment")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(100000)
+    CONVERSATION_FEE = sp.mutez(100000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = direct_messages_module.DirectMessages(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        conversation_fee=CONVERSATION_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+
+
+
+# ==============================================================================
+# token gated Tests
+# ==============================================================================
+
+
+# --- Test: Token holder posts ---
+
+@sp.add_test()
+def test_token_holder_posts():
+    """Test that token holders can post messages."""
+    scenario = sp.test_scenario("token_holder_posts", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Token Holder Posts")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    # Give Alice token 0
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+
+    # Alice posts to token 0's room
+    scenario.h2("Alice posts (holds token)")
+    contract.post_message(
+        sp.record(
+            fa2_address=fa2.address,
+            token_id=sp.nat(0),
+            content=sp.bytes("0x48656c6c6f"),
+            parent_id=sp.none,
+        ),
+        _sender=alice,
+    )
+
+    # Room should be created
+    scenario.verify(contract.data.rooms[1].message_count == 1)
+    scenario.verify(contract.data.messages[1].sender == alice.address)
+    scenario.verify(contract.data.messages[1].room_id == 1)
+
+    # Room key lookup works
+    room_id_result = sp.View(contract, "get_room_id")(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0))
+    )
+    scenario.verify(room_id_result == sp.Some(sp.nat(1)))
+
+
+# --- Test: Non-holder rejected ---
+
+@sp.add_test()
+def test_non_holder_rejected():
+    """Test that non-holders cannot post."""
+    scenario = sp.test_scenario("non_holder_rejected", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Non-Holder Rejected")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    # Bob has no tokens
+    scenario.h2("Bob rejected (no tokens)")
+    contract.post_message(
+        sp.record(
+            fa2_address=fa2.address,
+            token_id=sp.nat(0),
+            content=sp.bytes("0x4e6f7065"),
+            parent_id=sp.none,
+        ),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_TOKEN_HOLDER",
+    )
+
+
+# --- Test: Multiple holders same room ---
+
+@sp.add_test()
+def test_multiple_holders():
+    """Test multiple holders posting to the same room."""
+    scenario = sp.test_scenario("multiple_holders", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Multiple Holders")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    # Give tokens
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+    fa2.set_balance(sp.record(owner=bob.address, token_id=sp.nat(0), balance=sp.nat(3)), _sender=admin)
+
+    # Both post
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x416c696365"), parent_id=sp.none),
+        _sender=alice,
+    )
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x426f62"), parent_id=sp.none),
+        _sender=bob,
+    )
+
+    # Same room, 2 messages
+    scenario.verify(contract.data.rooms[1].message_count == 2)
+    scenario.verify(contract.data.messages[1].sender == alice.address)
+    scenario.verify(contract.data.messages[2].sender == bob.address)
+
+
+# --- Test: Different tokens, different rooms ---
+
+@sp.add_test()
+def test_different_rooms():
+    """Test that different tokens get different rooms."""
+    scenario = sp.test_scenario("different_rooms", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Different Rooms")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(1), balance=sp.nat(1)), _sender=admin)
+
+    # Post to token 0
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x526f6f6d30"), parent_id=sp.none),
+        _sender=alice,
+    )
+
+    # Post to token 1
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(1), content=sp.bytes("0x526f6f6d31"), parent_id=sp.none),
+        _sender=alice,
+    )
+
+    # Two different rooms
+    scenario.verify(contract.data.rooms[1].message_count == 1)
+    scenario.verify(contract.data.rooms[2].message_count == 1)
+    scenario.verify(contract.data.messages[1].room_id == 1)
+    scenario.verify(contract.data.messages[2].room_id == 2)
+
+
+# --- Test: Replies ---
+
+@sp.add_test()
+def test_replies():
+    """Test reply functionality in token rooms."""
+    scenario = sp.test_scenario("tg_replies", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Replies")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+    fa2.set_balance(sp.record(owner=bob.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+
+    # Top-level message
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x48656c6c6f"), parent_id=sp.none),
+        _sender=alice,
+    )
+    scenario.verify(~contract.data.messages[1].parent_id.is_some())
+
+    # Reply
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x5265706c79"), parent_id=sp.Some(sp.nat(1))),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[2].parent_id.is_some())
+
+    # Reply to non-existent message
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x4e6f"), parent_id=sp.Some(sp.nat(999))),
+        _sender=alice,
+        _valid=False,
+        _exception="PARENT_NOT_FOUND",
+    )
+
+
+# --- Test: Delete message ---
+
+@sp.add_test()
+def test_delete_message():
+    """Test message deletion — sender only."""
+    scenario = sp.test_scenario("tg_delete", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Delete Message")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+    fa2.set_balance(sp.record(owner=bob.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+    )
+
+    # Bob cannot delete Alice's message
+    contract.delete_message(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_AUTHORIZED")
+
+    # Alice deletes her own message
+    contract.delete_message(sp.nat(1), _sender=alice)
+    scenario.verify(~contract.data.messages.contains(sp.nat(1)))
+    scenario.verify(contract.data.rooms[1].message_count == 0)
+
+
+# --- Test: Edge cases ---
+
+@sp.add_test()
+def test_edge_cases():
+    """Test edge cases."""
+    scenario = sp.test_scenario("tg_edge_cases", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Edge Cases")
+    admin, alice, bob, charlie, multisig, fa2, contract = _setup(scenario)
+
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+
+    # Empty content
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x"), parent_id=sp.none),
+        _sender=alice,
+        _valid=False,
+        _exception="EMPTY_CONTENT",
+    )
+
+    # Non-existent room lookup returns None
+    room_id_result = sp.View(contract, "get_room_id")(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(999))
+    )
+    scenario.verify(~room_id_result.is_some())
+
+    # Delete non-existent message
+    contract.delete_message(sp.nat(999), _sender=alice, _valid=False, _exception="MESSAGE_NOT_FOUND")
+
+
+# --- Test: Fees ---
+
+@sp.add_test()
+def test_fees():
+    """Test message fees."""
+    scenario = sp.test_scenario("tg_fees", [mock_multisig_module, mock_fa2_module, token_gate_module])
+    scenario.h1("Fees")
+    admin = sp.test_account("Admin")
+    alice = sp.test_account("Alice")
+
+    multisig = mock_multisig_module.MockMultisig(
+        users={admin.address},
+        minimum_votes=sp.nat(1),
+        expiration_time=sp.nat(30),
+    )
+    scenario += multisig
+
+    fa2 = mock_fa2_module.MockFA2()
+    scenario += fa2
+
+    contract = token_gate_module.TokenGate(
+        multisig_address=multisig.address,
+        fee_recipient=admin.address,
+        message_fee=sp.mutez(100),
+        metadata=sp.big_map({"": sp.scenario_utils.bytes_of_string("ipfs://test")}),
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+    fa2.set_balance(sp.record(owner=alice.address, token_id=sp.nat(0), balance=sp.nat(1)), _sender=admin)
+
+    # Wrong fee
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+        _amount=sp.mutez(0),
+        _valid=False,
+        _exception="INCORRECT_FEE",
+    )
+
+    # Correct fee
+    contract.post_message(
+        sp.record(fa2_address=fa2.address, token_id=sp.nat(0), content=sp.bytes("0x4869"), parent_id=sp.none),
+        _sender=alice,
+        _amount=sp.mutez(100),
+    )
+
+
+
+@sp.add_test()
+def deploy():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("deploy", token_gate_module)
+    scenario.h1("Token Gate - Deployment")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(0)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = token_gate_module.TokenGate(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+# ==============================================================================
+# channel tests
+# ==============================================================================
+
+
+# ==============================================================================
+# Mock Multisig for Testing
+# ==============================================================================
+
+
+@sp.module
+def mock_multisig_module():
+    class MockMultisig(sp.Contract):
+        def __init__(self, users, minimum_votes, expiration_time):
+            self.data.users = sp.cast(users, sp.set[sp.address])
+            self.data.minimum_votes = sp.cast(minimum_votes, sp.nat)
+            self.data.expiration_time = sp.cast(expiration_time, sp.nat)
+
+        @sp.onchain_view()
+        def is_user(self, address):
+            sp.cast(address, sp.address)
+            return address in self.data.users
+
+        @sp.onchain_view()
+        def get_minimum_votes(self):
+            return self.data.minimum_votes
+
+        @sp.onchain_view()
+        def get_expiration_time(self):
+            return self.data.expiration_time
+
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+
+def _setup(scenario, message_fee=sp.mutez(0), channel_fee=sp.mutez(0)):
+    """Shared test setup."""
+    admin = sp.test_account("Admin")
+    alice = sp.test_account("Alice")
+    bob = sp.test_account("Bob")
+    charlie = sp.test_account("Charlie")
+    dave = sp.test_account("Dave")
+
+    multisig = mock_multisig_module.MockMultisig(
+        users=sp.set([admin.address]),
+        minimum_votes=sp.nat(1),
+        expiration_time=sp.nat(7),
+    )
+    scenario += multisig
+
+    contract = channel_merkle_module.ChannelMerkle(
+        multisig_address=multisig.address,
+        fee_recipient=admin.address,
+        message_fee=message_fee,
+        channel_fee=channel_fee,
+        metadata=sp.big_map(),
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+    return admin, alice, bob, charlie, dave, multisig, contract
+
+
+# --- Test 1: Create channel ---
+
+@sp.add_test()
+def test_create_channel():
+    """Test creating channels."""
+    scenario = sp.test_scenario("create_channel", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Create Channel")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    # Alice creates a channel
+    scenario.h2("Alice creates channel")
+    contract.create_channel(
+        sp.bytes("0x697066733a2f2f6d657461"),
+        _sender=alice,
+    )
+    scenario.verify(contract.data.channels.contains(1))
+    scenario.verify(contract.data.channels[1].creator == alice.address)
+    scenario.verify(contract.data.channel_id_counter == 2)
+
+    # Bob creates a channel
+    scenario.h2("Bob creates channel")
+    contract.create_channel(
+        sp.bytes("0x697066733a2f2f626f62"),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.channels.contains(2))
+    scenario.verify(contract.data.channel_id_counter == 3)
+
+    # Empty metadata fails
+    scenario.h2("Empty metadata fails")
+    contract.create_channel(
+        sp.bytes("0x"),
+        _sender=alice,
+        _valid=False,
+        _exception="EMPTY_METADATA",
+    )
+
+
+# --- Test 2: Post to open channel ---
+
+@sp.add_test()
+def test_post_open_channel():
+    """Test posting to an open channel — anyone can post."""
+    scenario = sp.test_scenario("post_open", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Post to Open Channel")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Anyone can post
+    scenario.h2("Bob posts")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x48656c6c6f"),
+            proof=sp.none,
+            parent_id=sp.none,
+        ),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[1].sender == bob.address)
+    scenario.verify(contract.data.messages[1].channel_id == 1)
+
+    channel = sp.View(contract, "get_channel")(sp.nat(1))
+    scenario.verify(channel.message_count == 1)
+
+    # Charlie posts
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x576f726c64"), proof=sp.none, parent_id=sp.none),
+        _sender=charlie,
+    )
+    scenario.verify(contract.data.message_id_counter == 3)
+
+
+# --- Test 3: Configure channel as allowlist ---
+
+@sp.add_test()
+def test_configure_allowlist():
+    """Test configuring a channel with allowlist mode."""
+    scenario = sp.test_scenario("configure_allowlist", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Configure Channel - Allowlist")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Only creator can configure
+    scenario.h2("Non-creator cannot configure")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.allowlist(()),
+            merkle_root=sp.Some(sp.bytes("0x" + "aa" * 32)),
+            merkle_uri=sp.Some(sp.bytes("0x697066733a2f2f6c697374")),
+        ),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_ADMIN",
+    )
+
+    # Creator configures allowlist
+    scenario.h2("Creator sets allowlist")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.allowlist(()),
+            merkle_root=sp.Some(sp.bytes("0x" + "aa" * 32)),
+            merkle_uri=sp.Some(sp.bytes("0x697066733a2f2f6c697374")),
+        ),
+        _sender=alice,
+    )
+    scenario.verify(contract.data.channels[1].merkle_root.is_some())
+    scenario.verify(contract.data.channels[1].merkle_root.is_some())
+
+    # Allowlist without root fails
+    scenario.h2("Allowlist without root fails")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.allowlist(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+        _valid=False,
+        _exception="ALLOWLIST_NEEDS_ROOT",
+    )
+
+    # Open with root fails
+    scenario.h2("Open mode with root fails")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.Some(sp.bytes("0x" + "aa" * 32)),
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+        _valid=False,
+        _exception="UNRESTRICTED_NO_ROOT",
+    )
+
+    # Blocklist with root fails
+    scenario.h2("Blocklist with root fails")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.blocklist(()),
+            merkle_root=sp.Some(sp.bytes("0x" + "aa" * 32)),
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+        _valid=False,
+        _exception="BLOCKLIST_NO_ROOT",
+    )
+
+    # Back to open
+    scenario.h2("Back to open")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+    )
+    scenario.verify(~contract.data.channels[1].merkle_root.is_some())
+
+
+# We use a helper contract to compute Merkle leaves and roots on-chain,
+# since sp.pack() uses Michelson encoding that can't be replicated in Python.
+
+@sp.module
+def merkle_helper_module():
+    """Helper contract to compute Merkle leaves, intermediate nodes, and roots for testing."""
+
+    class MerkleHelper(sp.Contract):
+        def __init__(self):
+            self.data.leaf1 = sp.bytes("0x")
+            self.data.leaf2 = sp.bytes("0x")
+            self.data.leaf3 = sp.bytes("0x")
+            self.data.left_node = sp.bytes("0x")   # blake2b(leaf1 + leaf2)
+            self.data.right_node = sp.bytes("0x")   # blake2b(leaf3 + leaf3)
+            self.data.root_2 = sp.bytes("0x")
+            self.data.root_3 = sp.bytes("0x")
+
+        @sp.entrypoint
+        def compute_leaves(self, params):
+            sp.cast(params, sp.record(addr1=sp.address, addr2=sp.address, addr3=sp.address))
+            self.data.leaf1 = sp.blake2b(sp.pack(params.addr1))
+            self.data.leaf2 = sp.blake2b(sp.pack(params.addr2))
+            self.data.leaf3 = sp.blake2b(sp.pack(params.addr3))
+
+            # 2-leaf tree: root = blake2b(leaf1 + leaf2)
+            self.data.root_2 = sp.blake2b(self.data.leaf1 + self.data.leaf2)
+
+            # 3-leaf tree:
+            #         root_3
+            #        /      \
+            #   left_node   right_node
+            #    / \          / \
+            # leaf1 leaf2  leaf3 leaf3
+            self.data.left_node = sp.blake2b(self.data.leaf1 + self.data.leaf2)
+            self.data.right_node = sp.blake2b(self.data.leaf3 + self.data.leaf3)
+            self.data.root_3 = sp.blake2b(self.data.left_node + self.data.right_node)
+
+
+@sp.add_test()
+def test_merkle_allowlist_full():
+    """Full Merkle allowlist test using helper to compute roots."""
+    scenario = sp.test_scenario(
+        "merkle_allowlist_full",
+        [mock_multisig_module, channel_merkle_module, merkle_helper_module],
+    )
+    scenario.h1("Merkle Allowlist - Full Test")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    # Use helper to compute leaves and root
+    helper = merkle_helper_module.MerkleHelper()
+    scenario += helper
+
+    helper.compute_leaves(
+        addr1=bob.address,
+        addr2=charlie.address,
+        addr3=dave.address,
+        _sender=admin,
+    )
+
+    # Create channel
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Configure as allowlist with 2-leaf root (bob + charlie)
+    scenario.h2("Configure allowlist: bob + charlie")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.allowlist(()),
+            merkle_root=sp.Some(helper.data.root_2),
+            merkle_uri=sp.Some(sp.bytes("0x697066733a2f2f6c697374")),
+        ),
+        _sender=alice,
+    )
+
+    # Bob posts with valid proof: [{hash: leaf_charlie, direction: 1}]
+    scenario.h2("Bob posts with valid proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x48656c6c6f"),
+            proof=sp.Some([sp.record(hash=helper.data.leaf2, direction=sp.nat(1))]),
+            parent_id=sp.none,
+        ),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[1].sender == bob.address)
+
+    # Charlie posts with valid proof: [{hash: leaf_bob, direction: 0}]
+    scenario.h2("Charlie posts with valid proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x576f726c64"),
+            proof=sp.Some([sp.record(hash=helper.data.leaf1, direction=sp.nat(0))]),
+            parent_id=sp.none,
+        ),
+        _sender=charlie,
+    )
+    scenario.verify(contract.data.messages[2].sender == charlie.address)
+
+    # Dave is NOT in the allowlist — posts with empty proof, should fail
+    scenario.h2("Dave rejected — not in allowlist (empty proof)")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x4e6f7065"),
+            proof=sp.Some([]),
+            parent_id=sp.none,
+        ),
+        _sender=dave,
+        _valid=False,
+        _exception="INVALID_MERKLE_PROOF",
+    )
+
+    # Dave tries with bob's proof — should fail (wrong leaf)
+    scenario.h2("Dave rejected — wrong proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x4e6f7065"),
+            proof=sp.Some([sp.record(hash=helper.data.leaf2, direction=sp.nat(1))]),
+            parent_id=sp.none,
+        ),
+        _sender=dave,
+        _valid=False,
+        _exception="INVALID_MERKLE_PROOF",
+    )
+
+    # Post without proof when allowlist is set — fails
+    scenario.h2("No proof when allowlist active — fails")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x4e6f7065"),
+            proof=sp.none,
+            parent_id=sp.none,
+        ),
+        _sender=bob,
+        _valid=False,
+        _exception="PROOF_REQUIRED",
+    )
+
+    # Clear allowlist — back to open
+    scenario.h2("Clear allowlist — back to open")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+    )
+
+    # Dave can now post (open channel)
+    scenario.h2("Dave posts to open channel")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x4f70656e"),
+            proof=sp.none,
+            parent_id=sp.none,
+        ),
+        _sender=dave,
+    )
+    scenario.verify(contract.data.messages[3].sender == dave.address)
+
+
+# --- Test: 3-leaf Merkle tree ---
+
+@sp.add_test()
+def test_merkle_three_leaves():
+    """Test Merkle proof with 3 leaves (odd count — last node duplicated)."""
+    scenario = sp.test_scenario(
+        "merkle_3_leaves",
+        [mock_multisig_module, channel_merkle_module, merkle_helper_module],
+    )
+    scenario.h1("Merkle Allowlist - 3 Leaves")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    helper = merkle_helper_module.MerkleHelper()
+    scenario += helper
+
+    helper.compute_leaves(
+        addr1=bob.address,
+        addr2=charlie.address,
+        addr3=dave.address,
+        _sender=admin,
+    )
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Configure with 3-leaf root (bob, charlie, dave)
+    scenario.h2("Configure allowlist: bob + charlie + dave")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.allowlist(()),
+            merkle_root=sp.Some(helper.data.root_3),
+            merkle_uri=sp.Some(sp.bytes("0x697066733a2f2f6c697374")),
+        ),
+        _sender=alice,
+    )
+
+    # 3-leaf tree structure:
+    #         root_3
+    #        /      \
+    #   left_node   right_node
+    #    / \          / \
+    # leaf1 leaf2  leaf3 leaf3  (leaf3 duplicated)
+
+    # Bob (leaf1, index 0) proof:
+    #   Step 1: sibling=leaf2, direction=1 → compute left_node
+    #   Step 2: sibling=right_node, direction=1 → compute root
+    scenario.h2("Bob posts with 3-leaf proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x426f62"),
+            proof=sp.Some([
+                sp.record(hash=helper.data.leaf2, direction=sp.nat(1)),
+                sp.record(hash=helper.data.right_node, direction=sp.nat(1)),
+            ]),
+            parent_id=sp.none,
+        ),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[1].sender == bob.address)
+
+    # Charlie (leaf2, index 1) proof:
+    #   Step 1: sibling=leaf1, direction=0 → compute left_node
+    #   Step 2: sibling=right_node, direction=1 → compute root
+    scenario.h2("Charlie posts with 3-leaf proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x436861726c6965"),
+            proof=sp.Some([
+                sp.record(hash=helper.data.leaf1, direction=sp.nat(0)),
+                sp.record(hash=helper.data.right_node, direction=sp.nat(1)),
+            ]),
+            parent_id=sp.none,
+        ),
+        _sender=charlie,
+    )
+    scenario.verify(contract.data.messages[2].sender == charlie.address)
+
+    # Dave (leaf3, index 2) proof:
+    #   Step 1: sibling=leaf3, direction=1 (duplicated) → compute right_node
+    #   Step 2: sibling=left_node, direction=0 → compute root
+    scenario.h2("Dave posts with 3-leaf proof")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x44617665"),
+            proof=sp.Some([
+                sp.record(hash=helper.data.leaf3, direction=sp.nat(1)),
+                sp.record(hash=helper.data.left_node, direction=sp.nat(0)),
+            ]),
+            parent_id=sp.none,
+        ),
+        _sender=dave,
+    )
+    scenario.verify(contract.data.messages[3].sender == dave.address)
+
+    # Admin is NOT in the tree — rejected
+    scenario.h2("Admin rejected — not in allowlist")
+    contract.post_message(
+        sp.record(
+            channel_id=sp.nat(1),
+            content=sp.bytes("0x4e6f7065"),
+            proof=sp.Some([
+                sp.record(hash=helper.data.leaf2, direction=sp.nat(1)),
+                sp.record(hash=helper.data.right_node, direction=sp.nat(1)),
+            ]),
+            parent_id=sp.none,
+        ),
+        _sender=admin,
+        _valid=False,
+        _exception="INVALID_MERKLE_PROOF",
+    )
+
+
+# --- Test: Blocklist ---
+
+@sp.add_test()
+def test_blocklist():
+    """Test blocklist mode — blocked addresses rejected."""
+    scenario = sp.test_scenario("blocklist", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Blocklist")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Configure as blocklist
+    scenario.h2("Configure as blocklist")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.blocklist(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+    )
+
+    # Anyone can post initially
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[1].sender == bob.address)
+
+    # Block Bob
+    scenario.h2("Block Bob")
+    contract.update_blocklist(
+        sp.record(
+            channel_id=sp.nat(1),
+            to_block=[bob.address],
+            to_unblock=[],
+        ),
+        _sender=alice,
+    )
+
+    # Bob is blocked
+    scenario.h2("Bob cannot post")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4e6f7065"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _valid=False,
+        _exception="ADDRESS_BLOCKED",
+    )
+
+    # Charlie can still post
+    scenario.h2("Charlie can still post")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x596573"), proof=sp.none, parent_id=sp.none),
+        _sender=charlie,
+    )
+
+    # Verify is_blocked view
+    blocked_result = sp.View(contract, "is_blocked")(
+        sp.record(channel_id=sp.nat(1), address=bob.address)
+    )
+    scenario.verify(blocked_result == True)
+
+    not_blocked_result = sp.View(contract, "is_blocked")(
+        sp.record(channel_id=sp.nat(1), address=charlie.address)
+    )
+    scenario.verify(not_blocked_result == False)
+
+    # Unblock Bob
+    scenario.h2("Unblock Bob")
+    contract.update_blocklist(
+        sp.record(
+            channel_id=sp.nat(1),
+            to_block=[],
+            to_unblock=[bob.address],
+        ),
+        _sender=alice,
+    )
+
+    # Bob can post again
+    scenario.h2("Bob can post again")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4261636b"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+
+    # Non-creator cannot update blocklist
+    scenario.h2("Non-creator cannot update blocklist")
+    contract.update_blocklist(
+        sp.record(channel_id=sp.nat(1), to_block=[dave.address], to_unblock=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_ADMIN",
+    )
+
+    # Cannot update blocklist when not in blocklist mode
+    scenario.h2("Cannot update blocklist in open mode")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+    )
+    contract.update_blocklist(
+        sp.record(channel_id=sp.nat(1), to_block=[bob.address], to_unblock=[]),
+        _sender=alice,
+        _valid=False,
+        _exception="NOT_BLOCKLIST_MODE",
+    )
+
+
+# --- Test: Delete message ---
+
+@sp.add_test()
+def test_delete_message():
+    """Test message deletion — sender and creator can delete."""
+    scenario = sp.test_scenario("delete_message", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Delete Message")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Bob posts
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+
+    # Charlie cannot delete Bob's message
+    scenario.h2("Non-author/non-creator cannot delete")
+    contract.delete_message(sp.nat(1), _sender=charlie, _valid=False, _exception="NOT_AUTHORIZED")
+
+    # Bob deletes his own
+    scenario.h2("Sender deletes own message")
+    contract.delete_message(sp.nat(1), _sender=bob)
+    scenario.verify(~contract.data.messages.contains(1))
+
+    # Post another
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x576f726c64"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+
+    # Alice (creator) moderates
+    scenario.h2("Creator moderates")
+    contract.delete_message(sp.nat(2), _sender=alice)
+    scenario.verify(~contract.data.messages.contains(2))
+
+
+# --- Test: Update channel metadata ---
+
+@sp.add_test()
+def test_update_channel():
+    """Test channel metadata update — creator only."""
+    scenario = sp.test_scenario("update_channel", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Update Channel")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6f6c64"), _sender=alice)
+
+    # Non-creator fails
+    contract.update_channel(
+        sp.record(channel_id=sp.nat(1), metadata_uri=sp.bytes("0x6e6577")),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_CREATOR",
+    )
+
+    # Creator updates
+    contract.update_channel(
+        sp.record(channel_id=sp.nat(1), metadata_uri=sp.bytes("0x6e6577")),
+        _sender=alice,
+    )
+    channel = sp.View(contract, "get_channel")(sp.nat(1))
+    scenario.verify(channel.metadata_uri == sp.bytes("0x6e6577"))
+
+
+# --- Test: Hide and delete channel ---
+
+@sp.add_test()
+def test_hide_and_delete_channel():
+    """Test hiding and deleting a channel."""
+    scenario = sp.test_scenario("hide_delete_channel", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Hide & Delete Channel")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Post a message first
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+
+    # Non-creator cannot hide
+    scenario.h2("Non-creator cannot hide")
+    contract.hide_channel(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_CHANNEL_CREATOR")
+
+    # Hide channel
+    scenario.h2("Creator hides channel")
+    contract.hide_channel(sp.nat(1), _sender=alice)
+    scenario.verify(contract.data.channels[1].hidden == True)
+
+    # Cannot post to hidden channel
+    scenario.h2("Cannot post to hidden channel")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4e6f"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _valid=False,
+        _exception="CHANNEL_HIDDEN",
+    )
+
+    # Cannot configure hidden channel
+    scenario.h2("Cannot configure hidden channel")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.blocklist(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=alice,
+        _valid=False,
+        _exception="CHANNEL_HIDDEN",
+    )
+
+    # Create another channel for delete test
+    contract.create_channel(sp.bytes("0x6d65746132"), _sender=alice)
+
+    # Non-creator cannot delete
+    scenario.h2("Non-creator cannot delete channel")
+    contract.delete_channel(sp.nat(2), _sender=bob, _valid=False, _exception="NOT_CHANNEL_CREATOR")
+
+    # Creator deletes
+    scenario.h2("Creator deletes channel")
+    contract.delete_channel(sp.nat(2), _sender=alice)
+    scenario.verify(~contract.data.channels.contains(2))
+
+
+# --- Test: Fee enforcement ---
+
+@sp.add_test()
+def test_fee_enforcement():
+    """Test channel and message fees."""
+    scenario = sp.test_scenario("fees", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Fee Enforcement")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(
+        scenario, message_fee=sp.mutez(100), channel_fee=sp.mutez(500)
+    )
+
+    # Create without fee fails
+    contract.create_channel(
+        sp.bytes("0x6d657461"),
+        _sender=alice,
+        _amount=sp.mutez(0),
+        _valid=False,
+        _exception="INCORRECT_FEE",
+    )
+
+    # Create with correct fee
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice, _amount=sp.mutez(500))
+
+    # Post without fee fails
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _amount=sp.mutez(0),
+        _valid=False,
+        _exception="INCORRECT_FEE",
+    )
+
+    # Post with correct fee
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _amount=sp.mutez(100),
+    )
+
+
+# --- Test: Governance ---
+
+@sp.add_test()
+def test_governance():
+    """Test governance: pause, fee changes."""
+    scenario = sp.test_scenario("governance", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Governance")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    # Non-user cannot submit
+    contract.submit_proposal(
+        sp.variant.set_pause(True),
+        _sender=alice,
+        _valid=False,
+        _exception="CHANNELS_NOT_MULTISIG_USER",
+    )
+
+    # Pause
+    scenario.h2("Pause")
+    contract.submit_proposal(sp.variant.set_pause(True), _sender=admin)
+    contract.vote_proposal(proposal_id=sp.nat(0), approval=True, _sender=admin)
+    contract.execute_proposal(sp.nat(0), _sender=admin)
+    scenario.verify(contract.data.paused == True)
+
+    # Cannot create when paused
+    contract.create_channel(
+        sp.bytes("0x6d657461"),
+        _sender=alice,
+        _valid=False,
+        _exception="CONTRACT_PAUSED",
+    )
+
+    # Unpause
+    scenario.h2("Unpause")
+    contract.submit_proposal(sp.variant.set_pause(False), _sender=admin)
+    contract.vote_proposal(proposal_id=sp.nat(1), approval=True, _sender=admin)
+    contract.execute_proposal(sp.nat(1), _sender=admin)
+    scenario.verify(contract.data.paused == False)
+
+    # Set fees
+    scenario.h2("Set channel fee")
+    contract.submit_proposal(sp.variant.set_channel_fee(sp.mutez(1000)), _sender=admin)
+    contract.vote_proposal(proposal_id=sp.nat(2), approval=True, _sender=admin)
+    contract.execute_proposal(sp.nat(2), _sender=admin)
+    scenario.verify(sp.View(contract, "get_channel_fee")() == sp.mutez(1000))
+
+
+# --- Test: Validation edge cases ---
+
+@sp.add_test()
+def test_validation():
+    """Test input validation edge cases."""
+    scenario = sp.test_scenario("validation", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Validation")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Empty content
+    scenario.h2("Empty content fails")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _valid=False,
+        _exception="EMPTY_CONTENT",
+    )
+
+    # Non-existent channel
+    scenario.h2("Post to non-existent channel")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(999), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+        _valid=False,
+        _exception="CHANNEL_NOT_FOUND",
+    )
+
+    # Delete non-existent message
+    scenario.h2("Delete non-existent message")
+    contract.delete_message(sp.nat(999), _sender=alice, _valid=False, _exception="MESSAGE_NOT_FOUND")
+
+    # Hide non-existent channel
+    scenario.h2("Hide non-existent channel")
+    contract.hide_channel(sp.nat(999), _sender=alice, _valid=False, _exception="CHANNEL_NOT_FOUND")
+
+    # Delete non-existent channel
+    scenario.h2("Delete non-existent channel")
+    contract.delete_channel(sp.nat(999), _sender=alice, _valid=False, _exception="CHANNEL_NOT_FOUND")
+
+
+# --- Test: Channel Admins ---
+
+
+@sp.add_test()
+def test_channel_admins():
+    """Test channel admin delegation."""
+    scenario = sp.test_scenario("channel_admins", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Channel Admins")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # Only creator can add admins
+    scenario.h2("Non-creator cannot add admins")
+    contract.update_channel_admins(
+        sp.record(channel_id=sp.nat(1), to_add=[bob.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_CREATOR",
+    )
+
+    # Creator adds bob as admin
+    scenario.h2("Creator adds Bob as admin")
+    contract.update_channel_admins(
+        sp.record(channel_id=sp.nat(1), to_add=[bob.address], to_remove=[]),
+        _sender=alice,
+    )
+
+    # Verify via view
+    is_admin_result = sp.View(contract, "is_channel_admin")(
+        sp.record(channel_id=sp.nat(1), address=bob.address)
+    )
+    scenario.verify(is_admin_result)
+
+    # Creator is also reported as admin
+    is_creator_admin = sp.View(contract, "is_channel_admin")(
+        sp.record(channel_id=sp.nat(1), address=alice.address)
+    )
+    scenario.verify(is_creator_admin)
+
+    # Non-admin is not admin
+    is_charlie_admin = sp.View(contract, "is_channel_admin")(
+        sp.record(channel_id=sp.nat(1), address=charlie.address)
+    )
+    scenario.verify(~is_charlie_admin)
+
+    # Admin can configure channel
+    scenario.h2("Admin configures channel")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.blocklist(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=bob,
+    )
+
+    # Admin can update blocklist
+    scenario.h2("Admin updates blocklist")
+    contract.update_blocklist(
+        sp.record(channel_id=sp.nat(1), to_block=[dave.address], to_unblock=[]),
+        _sender=bob,
+    )
+
+    # Admin can delete messages
+    scenario.h2("Admin deletes message")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4869"), proof=sp.none, parent_id=sp.none),
+        _sender=charlie,
+    )
+    contract.delete_message(sp.nat(1), _sender=bob)
+    scenario.verify(~contract.data.messages.contains(sp.nat(1)))
+
+    # Non-admin cannot configure
+    scenario.h2("Non-admin cannot configure")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=charlie,
+        _valid=False,
+        _exception="NOT_CHANNEL_ADMIN",
+    )
+
+    # Admin cannot add other admins
+    scenario.h2("Admin cannot add other admins")
+    contract.update_channel_admins(
+        sp.record(channel_id=sp.nat(1), to_add=[charlie.address], to_remove=[]),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_CREATOR",
+    )
+
+    # Admin cannot hide channel
+    scenario.h2("Admin cannot hide channel")
+    contract.hide_channel(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_CHANNEL_CREATOR")
+
+    # Admin cannot delete channel
+    scenario.h2("Admin cannot delete channel")
+    contract.delete_channel(sp.nat(1), _sender=bob, _valid=False, _exception="NOT_CHANNEL_CREATOR")
+
+    # Creator removes admin
+    scenario.h2("Creator removes Bob as admin")
+    contract.update_channel_admins(
+        sp.record(channel_id=sp.nat(1), to_add=[], to_remove=[bob.address]),
+        _sender=alice,
+    )
+
+    # Bob can no longer configure
+    scenario.h2("Removed admin cannot configure")
+    contract.configure_channel(
+        sp.record(
+            channel_id=sp.nat(1),
+            access_mode=sp.variant.unrestricted(()),
+            merkle_root=sp.none,
+            merkle_uri=sp.none,
+        ),
+        _sender=bob,
+        _valid=False,
+        _exception="NOT_CHANNEL_ADMIN",
+    )
+
+
+# --- Test: Message Replies ---
+
+
+@sp.add_test()
+def test_message_replies():
+    """Test posting replies to messages."""
+    scenario = sp.test_scenario("message_replies", [mock_multisig_module, channel_merkle_module])
+    scenario.h1("Message Replies")
+    admin, alice, bob, charlie, dave, multisig, contract = _setup(scenario)
+
+    contract.create_channel(sp.bytes("0x6d657461"), _sender=alice)
+
+    # 1. Post a top-level message
+    scenario.h2("Post top-level message")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x48656c6c6f"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[1].sender == bob.address)
+    scenario.verify(~contract.data.messages[1].parent_id.is_some())
+
+    # 2. Reply to that message
+    scenario.h2("Reply to message 1")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x5265706c79"), proof=sp.none, parent_id=sp.Some(sp.nat(1))),
+        _sender=charlie,
+    )
+    scenario.verify(contract.data.messages[2].sender == charlie.address)
+    scenario.verify(contract.data.messages[2].parent_id.is_some())
+
+    # 3. Reply to a reply (flat threading)
+    scenario.h2("Reply to a reply (flat)")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x5265706c7932"), proof=sp.none, parent_id=sp.Some(sp.nat(2))),
+        _sender=dave,
+    )
+    scenario.verify(contract.data.messages[3].sender == dave.address)
+    scenario.verify(contract.data.messages[3].parent_id.is_some())
+
+    # 4. Reply to non-existent message → PARENT_NOT_FOUND
+    scenario.h2("Reply to non-existent message")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x4e6f7065"), proof=sp.none, parent_id=sp.Some(sp.nat(999))),
+        _sender=bob,
+        _valid=False,
+        _exception="PARENT_NOT_FOUND",
+    )
+
+    # 5. Reply to message in different channel → PARENT_WRONG_CHANNEL
+    scenario.h2("Reply to message in different channel")
+    contract.create_channel(sp.bytes("0x6d65746132"), _sender=alice)
+    contract.post_message(
+        sp.record(channel_id=sp.nat(2), content=sp.bytes("0x4e6f7065"), proof=sp.none, parent_id=sp.Some(sp.nat(1))),
+        _sender=bob,
+        _valid=False,
+        _exception="PARENT_WRONG_CHANNEL",
+    )
+
+    # 6. Delete parent, replies remain
+    scenario.h2("Delete parent — replies remain")
+    contract.delete_message(sp.nat(1), _sender=bob)
+    scenario.verify(~contract.data.messages.contains(sp.nat(1)))
+    scenario.verify(contract.data.messages[2].sender == charlie.address)
+    scenario.verify(contract.data.messages[3].sender == dave.address)
+
+    # 7. Top-level post with parent_id = None works as before
+    scenario.h2("Top-level post still works")
+    contract.post_message(
+        sp.record(channel_id=sp.nat(1), content=sp.bytes("0x546f70"), proof=sp.none, parent_id=sp.none),
+        _sender=bob,
+    )
+    scenario.verify(contract.data.messages[4].sender == bob.address)
+    scenario.verify(~contract.data.messages[4].parent_id.is_some())
+
+
+# ==============================================================================
+# Deployment Scenario
+# ==============================================================================
+
+
+@sp.add_test()
+def deploy():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("deploy", channel_merkle_module)
+    scenario.h1("Channel Merkle - Deployment")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(0)
+    CHANNEL_FEE = sp.mutez(0)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = channel_merkle_module.ChannelMerkle(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        channel_fee=CHANNEL_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+
+
+
+
+
+
+@sp.add_test()
+def channel_deploy():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("channel_deploy", channels_module)
+    scenario.h1("Channel Merkle - Deployment")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(100000)
+    CHANNEL_FEE = sp.mutez(100000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = channels_module.Channels(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        channel_fee=CHANNEL_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+
+
+@sp.add_test()
+def deploy():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("deploy", token_gate_module)
+    scenario.h1("Token Gate - Deployment")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    MESSAGE_FEE = sp.mutez(100000)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://aaa"),
+        }
+    )
+
+    contract = token_gate_module.TokenGate(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        message_fee=MESSAGE_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract

--- a/python/contracts/messages/token_comments.py
+++ b/python/contracts/messages/token_comments.py
@@ -1,0 +1,781 @@
+import smartpy as sp
+
+
+@sp.module
+def token_comments_module():
+    """Teia Token Comments Contract.
+
+    Comments on Teia FA2 tokens, gated by ownership of the token being
+    commented on. The token gate is dynamic — each post specifies the
+    (fa2_address, token_id) it targets, and the caller must hold that
+    token. Multisig-governed moderation (hide/unhide) and parameter changes.
+
+    Error codes:
+
+    Comment:
+    - CONTRACT_PAUSED: Contract is globally paused
+    - TEZ_TRANSFER: Unexpected tez transfer
+    - INCORRECT_FEE: sp.amount does not match the required fee for the action
+      (post_fee for post_comment, edit_fee for edit_comment, hide_fee for
+      set_own_comment_hidden)
+    - EMPTY_CONTENT: Comment content is empty
+    - CONTENT_TOO_LARGE: Comment content exceeds 32 KiB
+    - PARENT_NOT_FOUND: Reply target comment does not exist
+    - PARENT_WRONG_TOKEN: Reply target is on a different token
+      (fa2_address or token_id mismatch)
+    - PARENT_HIDDEN: Reply target has been hidden
+    - COMMENT_NOT_FOUND: Comment ID does not exist
+    - NOT_AUTHORIZED: Caller cannot perform this action
+    - USER_BANNED: Caller is on the ban list (blocks post_comment and edit_comment)
+    - VERSION_NOT_FOUND: Requested historical version of a comment does not exist
+
+    Token gate / FA2:
+    - PENDING_POST_EXISTS: Another post_comment is mid-callback
+    - NO_PENDING_POST: balance_callback called with no pending comment
+    - INVALID_CALLBACK_SENDER: balance_callback sender is not the FA2
+      that post_comment targeted
+    - EMPTY_BALANCE_RESPONSE: FA2 returned no balance entries
+    - NOT_TOKEN_HOLDER: Sender does not hold the targeted token
+    - SELF_CALLBACK_ERROR: Could not resolve self balance_callback entrypoint
+    - INVALID_FA2: Targeted FA2 contract has no balance_of entrypoint
+
+    Governance (multisig-gated):
+    - TC_VIEW_FAILED: is_user view on multisig failed
+    - TC_NOT_MULTISIG_USER: Caller is not a multisig user
+    - TC_GET_MIN_VOTES_FAILED: get_minimum_votes view failed
+    - TC_GET_EXPIRATION_FAILED: get_expiration_time view failed
+    - TC_PROPOSAL_EXPIRED: Proposal past expiration window
+    - TC_NO_PROPOSAL: Proposal ID does not exist
+    - TC_ALREADY_EXECUTED: Proposal already executed
+    - TC_NOT_ENOUGH_VOTES: Positive votes below minimum
+    """
+
+    # ===========================================================================
+    # Types
+    # ===========================================================================
+
+    # --- FA2 Types (TZIP-12 standard) ---
+
+    balance_of_request_type: type = sp.record(
+        owner=sp.address,
+        token_id=sp.nat,
+    ).layout(("owner", "token_id"))
+
+    balance_of_response_type: type = sp.record(
+        request=balance_of_request_type,
+        balance=sp.nat,
+    ).layout(("request", "balance"))
+
+    balance_of_params_type: type = sp.record(
+        callback=sp.contract[sp.list[balance_of_response_type]],
+        requests=sp.list[balance_of_request_type],
+    ).layout(("requests", "callback"))
+
+    # --- Comment ---
+
+    comment_type: type = sp.record(
+        fa2_address=sp.address,
+        token_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        hidden=sp.bool,
+        timestamp=sp.timestamp,
+        version=sp.nat,
+    )
+
+    # --- Comment History ---
+    # Snapshot of a prior version of a comment.
+    # The live version lives in `comments`; `comment_history[(comment_id, n)]`
+    # holds the n-th archived version. Versions start at 1; archived indices
+    # 1..comment.version-1 are populated (empty for never-edited comments at
+    # version=1).
+
+    history_entry_type: type = sp.record(
+        fa2_address=sp.address,
+        token_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        timestamp=sp.timestamp,
+    )
+
+    history_key_type: type = sp.pair[sp.nat, sp.nat]
+
+    # --- Pending Post (for balance_of callback) ---
+
+    pending_comment_type: type = sp.record(
+        fa2_address=sp.address,
+        token_id=sp.nat,
+        sender=sp.address,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+        fee=sp.mutez,
+    )
+
+    # --- Entrypoint Params ---
+
+    post_comment_params_type: type = sp.record(
+        fa2_address=sp.address,
+        token_id=sp.nat,
+        content=sp.bytes,
+        parent_id=sp.option[sp.nat],
+    )
+
+    edit_comment_params_type: type = sp.record(
+        comment_id=sp.nat,
+        content=sp.bytes,
+    )
+
+    set_own_comment_hidden_params_type: type = sp.record(
+        comment_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    # --- Storage Types ---
+
+    comments_map_type: type = sp.big_map[sp.nat, comment_type]
+    metadata_type: type = sp.big_map[sp.string, sp.bytes]
+
+    # --- Governance Types ---
+
+    metadata_entry_type: type = sp.record(
+        key=sp.string,
+        value=sp.bytes,
+    ).layout(("key", "value"))
+
+    user_banned_action_type: type = sp.record(
+        address=sp.address,
+        banned=sp.bool,
+    ).layout(("address", "banned"))
+
+    proposal_action_type: type = sp.variant(
+        set_pause=sp.bool,
+        set_post_fee=sp.mutez,
+        set_edit_fee=sp.mutez,
+        set_hide_fee=sp.mutez,
+        set_fee_recipient=sp.address,
+        update_multisig_address=sp.address,
+        update_metadata=metadata_entry_type,
+        set_user_banned=user_banned_action_type,
+    )
+
+    moderate_comment_hidden_params_type: type = sp.record(
+        comment_id=sp.nat,
+        hidden=sp.bool,
+    )
+
+    proposal_type: type = sp.record(
+        action=proposal_action_type,
+        executed=sp.bool,
+        issuer=sp.address,
+        timestamp=sp.timestamp,
+        positive_votes=sp.nat,
+        negative_votes=sp.nat,
+    ).layout(
+        (
+            "action",
+            (
+                "executed",
+                (
+                    "issuer",
+                    ("timestamp", ("positive_votes", "negative_votes")),
+                ),
+            ),
+        )
+    )
+
+    vote_key_type: type = sp.pair[sp.nat, sp.address]
+
+    vote_params_type: type = sp.record(
+        proposal_id=sp.nat,
+        approval=sp.bool,
+    ).layout(("proposal_id", "approval"))
+
+    # ===========================================================================
+    # Contract
+    # ===========================================================================
+
+    class TokenComments(sp.Contract):
+        """Teia Token Comments — FA2 holders can comment on the specific
+        token they hold. Multisig governs moderation and parameter changes."""
+
+        def __init__(self, multisig_address, fee_recipient, post_fee, edit_fee, hide_fee, metadata, counter):
+            self.data.multisig_address = sp.cast(multisig_address, sp.address)
+            self.data.metadata = sp.cast(metadata, metadata_type)
+            self.data.paused = False
+            self.data.comments = sp.cast(sp.big_map(), comments_map_type)
+            self.data.comment_history = sp.cast(sp.big_map(), sp.big_map[history_key_type, history_entry_type])
+            self.data.banned = sp.cast(sp.big_map(), sp.big_map[sp.address, sp.unit])
+            self.data.pending_comment = sp.cast(None, sp.option[pending_comment_type])
+            self.data.comment_id_counter = sp.nat(1)
+            self.data.post_fee = sp.cast(post_fee, sp.mutez)
+            self.data.edit_fee = sp.cast(edit_fee, sp.mutez)
+            self.data.hide_fee = sp.cast(hide_fee, sp.mutez)
+            self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
+            self.data.proposals = sp.cast(sp.big_map(), sp.big_map[sp.nat, proposal_type])
+            self.data.votes = sp.cast(sp.big_map(), sp.big_map[vote_key_type, sp.bool])
+            self.data.counter = sp.cast(counter, sp.nat)
+
+        # =======================================================================
+        # Private Helpers
+        # =======================================================================
+
+        @sp.private(with_storage="read-only")
+        def _check_not_paused(self):
+            assert not self.data.paused, "CONTRACT_PAUSED"
+
+        @sp.private(with_storage="read-only")
+        def _check_no_tez_transfer(self):
+            assert sp.amount == sp.tez(0), "TEZ_TRANSFER"
+
+        @sp.private(with_storage="read-only")
+        def _check_not_banned(self):
+            assert not (sp.sender in self.data.banned), "USER_BANNED"
+
+        @sp.private(with_storage="read-only")
+        def _check_is_user(self):
+            is_user = sp.view(
+                "is_user",
+                self.data.multisig_address,
+                sp.sender,
+                sp.bool,
+            ).unwrap_some(error="TC_VIEW_FAILED")
+            assert is_user, "TC_NOT_MULTISIG_USER"
+
+        @sp.private(with_storage="read-only")
+        def _get_minimum_votes(self):
+            return sp.view(
+                "get_minimum_votes",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="TC_GET_MIN_VOTES_FAILED")
+
+        @sp.private(with_storage="read-only")
+        def _check_not_expired(self, timestamp):
+            expiration_days = sp.view(
+                "get_expiration_time",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="TC_GET_EXPIRATION_FAILED")
+
+            expiration_seconds = sp.to_int(expiration_days * 86400)
+            expiration_time = sp.add_seconds(timestamp, expiration_seconds)
+            assert not (sp.now > expiration_time), "TC_PROPOSAL_EXPIRED"
+
+        @sp.private(with_storage="read-write", with_operations=True)
+        def _send_fee(self, fee):
+            """Sends fee to fee_recipient if > 0."""
+            if fee > sp.mutez(0):
+                sp.send(self.data.fee_recipient, fee)
+
+        # =======================================================================
+        # Comment Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def post_comment(self, params):
+            """Post a comment on a Teia FA2 token. Initiates FA2 balance check
+            against the targeted (fa2_address, token_id)."""
+            sp.cast(params, post_comment_params_type)
+            self._check_not_paused()
+            self._check_not_banned()
+
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+            assert not self.data.pending_comment.is_some(), "PENDING_POST_EXISTS"
+
+            assert sp.amount == self.data.post_fee, "INCORRECT_FEE"
+
+            # Validate parent comment if replying
+            if params.parent_id.is_some():
+                parent_comment_id = params.parent_id.unwrap_some()
+                assert parent_comment_id in self.data.comments, "PARENT_NOT_FOUND"
+                parent_comment = self.data.comments[parent_comment_id]
+                assert parent_comment.fa2_address == params.fa2_address, "PARENT_WRONG_TOKEN"
+                assert parent_comment.token_id == params.token_id, "PARENT_WRONG_TOKEN"
+                assert not parent_comment.hidden, "PARENT_HIDDEN"
+
+            self.data.pending_comment = sp.Some(sp.record(
+                fa2_address=params.fa2_address,
+                token_id=params.token_id,
+                sender=sp.sender,
+                content=params.content,
+                parent_id=params.parent_id,
+                fee=sp.amount,
+            ))
+
+            callback = sp.contract(
+                sp.list[balance_of_response_type],
+                sp.self_address,
+                entrypoint="balance_callback",
+            ).unwrap_some(error="SELF_CALLBACK_ERROR")
+
+            fa2_handle = sp.contract(
+                balance_of_params_type,
+                params.fa2_address,
+                entrypoint="balance_of",
+            ).unwrap_some(error="INVALID_FA2")
+
+            sp.transfer(
+                sp.record(
+                    requests=[sp.record(owner=sp.sender, token_id=params.token_id)],
+                    callback=callback,
+                ),
+                sp.tez(0),
+                fa2_handle,
+            )
+
+        @sp.entrypoint
+        def balance_callback(self, responses):
+            """Callback from FA2 balance_of. Writes comment if balance > 0."""
+            sp.cast(responses, sp.list[balance_of_response_type])
+
+            pending = self.data.pending_comment.unwrap_some(error="NO_PENDING_POST")
+
+            # Caller must be the FA2 contract that post_comment targeted
+            assert sp.sender == pending.fa2_address, "INVALID_CALLBACK_SENDER"
+
+            assert sp.len(responses) > 0, "EMPTY_BALANCE_RESPONSE"
+            found_balance = sp.nat(0)
+            for response in responses:
+                if response.request.owner == pending.sender:
+                    if response.request.token_id == pending.token_id:
+                        found_balance = response.balance
+            assert found_balance > 0, "NOT_TOKEN_HOLDER"
+
+            comment_id = self.data.comment_id_counter
+            self.data.comments[comment_id] = sp.record(
+                fa2_address=pending.fa2_address,
+                token_id=pending.token_id,
+                sender=pending.sender,
+                content=pending.content,
+                parent_id=pending.parent_id,
+                hidden=False,
+                timestamp=sp.now,
+                version=sp.nat(1),
+            )
+
+            self.data.comment_id_counter += 1
+
+            self._send_fee(pending.fee)
+
+            # Note: `content` is intentionally NOT emitted in the event
+            sp.emit(
+                sp.record(
+                    fa2_address=pending.fa2_address,
+                    token_id=pending.token_id,
+                    comment_id=comment_id,
+                    sender=pending.sender,
+                    parent_id=pending.parent_id,
+                    timestamp=sp.now,
+                ),
+                tag="comment_posted",
+            )
+
+            self.data.pending_comment = None
+
+        @sp.entrypoint
+        def edit_comment(self, params):
+            """Edit a comment. Sender only. Archives the current version into
+            comment_history before overwriting content."""
+            sp.cast(params, edit_comment_params_type)
+            self._check_not_paused()
+            self._check_not_banned()
+
+            assert sp.amount == self.data.edit_fee, "INCORRECT_FEE"
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+            assert comment.sender == sp.sender, "NOT_AUTHORIZED"
+            assert sp.len(params.content) > 0, "EMPTY_CONTENT"
+            assert sp.len(params.content) <= 32768, "CONTENT_TOO_LARGE"
+
+            self.data.comment_history[(params.comment_id, comment.version)] = sp.record(
+                fa2_address=comment.fa2_address,
+                token_id=comment.token_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                timestamp=comment.timestamp,
+            )
+
+            new_version = comment.version + 1
+            self.data.comments[params.comment_id] = sp.record(
+                fa2_address=comment.fa2_address,
+                token_id=comment.token_id,
+                sender=comment.sender,
+                content=params.content,
+                parent_id=comment.parent_id,
+                hidden=comment.hidden,
+                timestamp=sp.now,
+                version=new_version,
+            )
+
+            self._send_fee(sp.amount)
+
+            sp.emit(
+                sp.record(
+                    fa2_address=comment.fa2_address,
+                    token_id=comment.token_id,
+                    comment_id=params.comment_id,
+                    sender=comment.sender,
+                    parent_id=comment.parent_id,
+                    timestamp=sp.now,
+                    version=new_version,
+                ),
+                tag="comment_edited",
+            )
+
+        @sp.entrypoint
+        def set_own_comment_hidden(self, params):
+            """Toggle hidden flag on caller's own comment."""
+            sp.cast(params, set_own_comment_hidden_params_type)
+            self._check_not_paused()
+
+            assert sp.amount == self.data.hide_fee, "INCORRECT_FEE"
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+            assert comment.sender == sp.sender, "NOT_AUTHORIZED"
+
+            self.data.comments[params.comment_id] = sp.record(
+                fa2_address=comment.fa2_address,
+                token_id=comment.token_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                hidden=params.hidden,
+                timestamp=comment.timestamp,
+                version=comment.version,
+            )
+
+            self._send_fee(sp.amount)
+
+            sp.emit(
+                sp.record(
+                    comment_id=params.comment_id,
+                    hidden=params.hidden,
+                    updated_by=sp.sender,
+                ),
+                tag="comment_hidden_set",
+            )
+
+        @sp.entrypoint
+        def moderate_comment_hidden(self, params):
+            """Hide or unhide any comment. Any multisig user, no vote required."""
+            sp.cast(params, moderate_comment_hidden_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            assert params.comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            comment = self.data.comments[params.comment_id]
+
+            self.data.comments[params.comment_id] = sp.record(
+                fa2_address=comment.fa2_address,
+                token_id=comment.token_id,
+                sender=comment.sender,
+                content=comment.content,
+                parent_id=comment.parent_id,
+                hidden=params.hidden,
+                timestamp=comment.timestamp,
+                version=comment.version,
+            )
+
+            sp.emit(
+                sp.record(
+                    comment_id=params.comment_id,
+                    hidden=params.hidden,
+                    moderator=sp.sender,
+                ),
+                tag="comment_moderated",
+            )
+
+        # =======================================================================
+        # Governance Entrypoints
+        # =======================================================================
+
+        @sp.entrypoint
+        def submit_proposal(self, action):
+            """Submit a new proposal."""
+            sp.cast(action, proposal_action_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+
+            self.data.proposals[self.data.counter] = sp.record(
+                action=action,
+                executed=False,
+                issuer=sp.sender,
+                timestamp=sp.now,
+                positive_votes=sp.nat(0),
+                negative_votes=sp.nat(0),
+            )
+            self.data.counter += 1
+
+        @sp.entrypoint
+        def vote_proposal(self, vote):
+            """Vote on an existing proposal."""
+            sp.cast(vote, vote_params_type)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert vote.proposal_id in self.data.proposals, "TC_NO_PROPOSAL"
+
+            proposal = self.data.proposals[vote.proposal_id]
+            assert not proposal.executed, "TC_ALREADY_EXECUTED"
+            self._check_not_expired(proposal.timestamp)
+
+            vote_key = (vote.proposal_id, sp.sender)
+
+            if vote_key in self.data.votes:
+                if self.data.votes[vote_key]:
+                    proposal.positive_votes = sp.as_nat(proposal.positive_votes - 1)
+                else:
+                    proposal.negative_votes = sp.as_nat(proposal.negative_votes - 1)
+
+            if vote.approval:
+                proposal.positive_votes += 1
+            else:
+                proposal.negative_votes += 1
+
+            self.data.votes[vote_key] = vote.approval
+            self.data.proposals[vote.proposal_id] = proposal
+
+        @sp.entrypoint
+        def execute_proposal(self, proposal_id):
+            """Execute an approved proposal."""
+            sp.cast(proposal_id, sp.nat)
+            self._check_no_tez_transfer()
+            self._check_is_user()
+            assert proposal_id in self.data.proposals, "TC_NO_PROPOSAL"
+
+            proposal = self.data.proposals[proposal_id]
+            assert not proposal.executed, "TC_ALREADY_EXECUTED"
+            minimum_votes = self._get_minimum_votes()
+            assert proposal.positive_votes >= minimum_votes, "TC_NOT_ENOUGH_VOTES"
+            self._check_not_expired(proposal.timestamp)
+
+            proposal.executed = True
+            self.data.proposals[proposal_id] = proposal
+
+            if proposal.action.is_variant.set_pause():
+                self.data.paused = proposal.action.unwrap.set_pause()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        paused=self.data.paused,
+                        updated_by=sp.sender,
+                    ),
+                    tag="pause_set",
+                )
+
+            if proposal.action.is_variant.set_post_fee():
+                self.data.post_fee = proposal.action.unwrap.set_post_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        post_fee=self.data.post_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="post_fee_set",
+                )
+
+            if proposal.action.is_variant.set_edit_fee():
+                self.data.edit_fee = proposal.action.unwrap.set_edit_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        edit_fee=self.data.edit_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="edit_fee_set",
+                )
+
+            if proposal.action.is_variant.set_hide_fee():
+                self.data.hide_fee = proposal.action.unwrap.set_hide_fee()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        hide_fee=self.data.hide_fee,
+                        updated_by=sp.sender,
+                    ),
+                    tag="hide_fee_set",
+                )
+
+            if proposal.action.is_variant.set_fee_recipient():
+                self.data.fee_recipient = proposal.action.unwrap.set_fee_recipient()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        fee_recipient=self.data.fee_recipient,
+                        updated_by=sp.sender,
+                    ),
+                    tag="fee_recipient_set",
+                )
+
+            if proposal.action.is_variant.update_multisig_address():
+                self.data.multisig_address = proposal.action.unwrap.update_multisig_address()
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        multisig_address=self.data.multisig_address,
+                        updated_by=sp.sender,
+                    ),
+                    tag="multisig_address_set",
+                )
+
+            if proposal.action.is_variant.update_metadata():
+                entry = proposal.action.unwrap.update_metadata()
+                self.data.metadata[entry.key] = entry.value
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        key=entry.key,
+                        updated_by=sp.sender,
+                    ),
+                    tag="metadata_updated",
+                )
+
+            if proposal.action.is_variant.set_user_banned():
+                ban = proposal.action.unwrap.set_user_banned()
+                if ban.banned:
+                    self.data.banned[ban.address] = ()
+                else:
+                    if ban.address in self.data.banned:
+                        del self.data.banned[ban.address]
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        address=ban.address,
+                        banned=ban.banned,
+                        updated_by=sp.sender,
+                    ),
+                    tag="user_banned_set",
+                )
+
+        # =======================================================================
+        # Views
+        # =======================================================================
+
+        @sp.onchain_view()
+        def get_comment(self, comment_id):
+            """Get comment by ID."""
+            sp.cast(comment_id, sp.nat)
+            assert comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            return self.data.comments[comment_id]
+
+        @sp.onchain_view()
+        def get_comment_version(self, key):
+            """Get an archived version of a comment.
+
+            `key` is `(comment_id, version)`. Returns the snapshot of the
+            comment at that version. Live state lives in `comments`."""
+            sp.cast(key, history_key_type)
+            assert key in self.data.comment_history, "VERSION_NOT_FOUND"
+            return self.data.comment_history[key]
+
+        @sp.onchain_view()
+        def get_comment_version_count(self, comment_id):
+            """Get the total version count for a comment.
+
+            Versions start at 1, so this returns 1 for a never-edited comment
+            and `1 + number_of_edits` otherwise. Archived snapshots exist at
+            `comment_history[(comment_id, 1..version-1)]`; the live version
+            (index = `version`) lives in `comments[comment_id]`."""
+            sp.cast(comment_id, sp.nat)
+            assert comment_id in self.data.comments, "COMMENT_NOT_FOUND"
+            return self.data.comments[comment_id].version
+
+        @sp.onchain_view()
+        def get_fees(self):
+            """Get the current post/edit/hide fees."""
+            return sp.record(
+                post_fee=self.data.post_fee,
+                edit_fee=self.data.edit_fee,
+                hide_fee=self.data.hide_fee,
+            )
+
+        @sp.onchain_view()
+        def get_proposal(self, proposal_id):
+            """Get proposal by ID."""
+            sp.cast(proposal_id, sp.nat)
+            assert proposal_id in self.data.proposals, "TC_NO_PROPOSAL"
+            return self.data.proposals[proposal_id]
+
+        @sp.onchain_view()
+        def get_vote(self, key):
+            """Get vote by key (proposal_id, voter)."""
+            sp.cast(key, vote_key_type)
+            return self.data.votes.get(key, default=False)
+
+        @sp.onchain_view()
+        def is_banned(self, address):
+            """Check if an address is on the ban list."""
+            sp.cast(address, sp.address)
+            return address in self.data.banned
+
+
+# ==============================================================================
+# Deployment Scenario
+# ==============================================================================
+
+
+@sp.add_test()
+def token_comments_deploy_shadownet():
+    """Deployment scenario."""
+    scenario = sp.test_scenario("token_comments_deploy_shadownet", token_comments_module)
+    scenario.h1("Token Comments - Deployment Shadownet")
+
+    MULTISIG_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP")
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmeNKK9t4xdeNo8NCyJtmmdEZ2p2CFzgnLyMmtoWzaCUWf"),
+        }
+    )
+
+    contract = token_comments_module.TokenComments(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract
+
+
+@sp.add_test()
+def token_comments_deploy_mainnet():
+    """Deployment scenario for Tezos mainnet."""
+    scenario = sp.test_scenario("token_comments_deploy_mainnet", token_comments_module)
+    scenario.h1("Token Comments - Deployment Mainnet")
+
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    FEE_RECIPIENT_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    POST_FEE = sp.mutez(25000)
+    EDIT_FEE = sp.mutez(0)
+    HIDE_FEE = sp.mutez(0)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string("ipfs://QmeNKK9t4xdeNo8NCyJtmmdEZ2p2CFzgnLyMmtoWzaCUWf"),
+        }
+    )
+
+    contract = token_comments_module.TokenComments(
+        multisig_address=MULTISIG_ADDRESS,
+        fee_recipient=FEE_RECIPIENT_ADDRESS,
+        post_fee=POST_FEE,
+        edit_fee=EDIT_FEE,
+        hide_fee=HIDE_FEE,
+        metadata=contract_metadata,
+        counter=sp.nat(0),
+    )
+    scenario += contract

--- a/python/contracts/messages/token_comments_README.md
+++ b/python/contracts/messages/token_comments_README.md
@@ -1,0 +1,222 @@
+# Token Comments
+
+On-chain comments on Teia FA2 tokens, gated by ownership of the specific token being commented on. Multisig governs moderation and parameter changes. Implemented in SmartPy at [`token_comments.py`](./token_comments.py).
+
+## Model
+
+- **Topic** of a comment is the pair `(fa2_address, token_id)`. There's no on-chain record of a "room" or "thread" — the topic is just two fields on each comment. Indexers can group by `(fa2_address, token_id)` from event data.
+- **Token gating is dynamic, per call.** Each `post_comment` carries the `(fa2_address, token_id)` it targets. The contract asks *that* FA2 for the sender's balance via `balance_of`, and only writes the comment when the callback confirms balance > 0. No FA2 address is baked into storage; there's no `update_token_gate` proposal.
+- **Replies** must match the parent's `(fa2_address, token_id)` — a comment on Teia token A can't be a reply to a comment on Teia token B. Hidden parents reject new replies.
+- **Moderation** is one flag (`hidden: bool`) on each comment. Three paths flip it: (a) the comment's sender via `set_own_comment_hidden`; (b) any multisig user via `moderate_comment_hidden` — no vote, just `is_user` check; (c) the sender can always un-hide their own comment. Nothing is ever hard-deleted.
+- **Editing** is allowed for the sender only. Each edit archives the *current* version into the `comment_history` big_map at key `(comment_id, version)` before overwriting `content` in place; the live `version` counter is then incremented and `timestamp` is reset to `sp.now`. The full prior version (`fa2_address`, `token_id`, `sender`, `content`, `parent_id`, `timestamp`) is preserved on chain forever and queryable via the `get_comment_version` view.
+- **Ban list** is contract-wide (not per-token). Multisig governance adds or removes addresses via the `set_user_banned` proposal action. A banned address is blocked from `post_comment` and `edit_comment` on every token; it can still toggle `set_own_comment_hidden` on its existing comments.
+
+## Storage
+
+```
+multisig_address     : address                                # governance contract
+metadata             : big_map[string, bytes]                 # TZIP-16
+paused               : bool                                   # global pause flag (governance-set)
+comments             : big_map[nat, comment]                  # flat comment store
+comment_history      : big_map[(nat, nat), history_entry]     # archived prior versions, keyed by (comment_id, version)
+banned               : big_map[address, unit]                 # contract-wide ban list (governance-set); presence = banned
+pending_comment      : option[pending_comment]                # populated during a balance_of round-trip
+comment_id_counter   : nat                                    # next comment_id (starts at 1)
+post_fee             : mutez                                  # required tez on post_comment (may be 0)
+edit_fee             : mutez                                  # required tez on edit_comment (may be 0)
+hide_fee             : mutez                                  # required tez on set_own_comment_hidden (may be 0)
+fee_recipient        : address
+proposals            : big_map[nat, proposal]                 # governance proposals
+votes                : big_map[(nat, address), bool]          # governance votes
+counter              : nat                                    # proposal counter
+```
+
+There is **no** `fa2_address` or `token_id` in storage — the gate is per-call, set by the post_comment caller.
+
+### `comment` record
+
+```
+fa2_address : address                   # the FA2 contract of the token being commented on
+token_id    : nat                       # the token id within that FA2
+sender      : address
+content     : bytes                     # ≤ 32768 bytes (32 KiB)
+parent_id   : option[nat]               # for threaded replies (must match this comment's (fa2_address, token_id))
+hidden      : bool                      # set by sender or multisig
+timestamp   : timestamp                 # when the *current* version became live (= post time at v1, reset to sp.now on each edit). Original post time is recoverable from `comment_history[(c, 1)].timestamp` once the comment has been edited at least once.
+version     : nat                       # current version index — starts at 1 on post, +1 per edit. Archived versions live at `comment_history[(comment_id, 1..version-1)]` (empty for never-edited comments at version=1).
+```
+
+### `history_entry` record
+
+```
+fa2_address : address                   # always the same as the live comment's fa2_address (comments can't be moved between tokens)
+token_id    : nat                       # always the same as the live comment's token_id
+sender      : address                   # always the original sender (only the sender can edit)
+content     : bytes                     # the content as it was at this version
+parent_id   : option[nat]               # always the same as the live comment's parent_id (reparenting not supported)
+timestamp   : timestamp                 # the moment this version became live (i.e. when it was posted or when the preceding edit happened)
+```
+
+## Entrypoints
+
+### Comment ops
+
+#### `post_comment(fa2_address, token_id, content, parent_id)`
+
+| | |
+|---|---|
+| Caller | anyone holding `(fa2_address, token_id)` at post time, not on the ban list |
+| Tez | exactly `post_fee` |
+| Behavior | stores `pending_comment` and calls `balance_of` on the targeted FA2; the comment is only written once `balance_callback` confirms a non-zero balance |
+| Validation | `1 ≤ len(content) ≤ 32768`; no other `pending_comment` in flight; if `parent_id` set, parent must exist, match this comment's `(fa2_address, token_id)`, and not be hidden |
+| Event | `comment_posted { fa2_address, token_id, comment_id, sender, parent_id, timestamp }` (emitted from `balance_callback`; content is intentionally not in the event so that edit/hide are meaningful) |
+
+#### `balance_callback(responses)`
+
+Internal-facing — must be called by the FA2 contract that the pending `post_comment` targeted. Writes the pending comment if a matching response shows balance > 0, sends the fee to `fee_recipient`, emits `comment_posted`, and clears `pending_comment`. Manual calls fail with `INVALID_CALLBACK_SENDER`. The check is `sp.sender == pending.fa2_address` — not a fixed FA2 address — since the gate is dynamic.
+
+#### `edit_comment(comment_id, content)`
+
+| | |
+|---|---|
+| Caller | original sender only, not on the ban list |
+| Tez | exactly `edit_fee` (may be 0) |
+| Behavior | snapshots the current version (`fa2_address`, `token_id`, `sender`, `content`, `parent_id`, `timestamp`) into `comment_history[(comment_id, version)]`, increments the live `version`, overwrites `content`, sets `timestamp = sp.now`. `fa2_address`, `token_id`, `parent_id`, and `hidden` are unchanged. Forwards the fee to `fee_recipient`. |
+| Validation | `1 ≤ len(content) ≤ 32768` |
+| Event | `comment_edited { fa2_address, token_id, comment_id, sender, parent_id, timestamp, version }` — `timestamp` is `sp.now` (the new live-since for this version); `version` is the new live version index; the just-archived snapshot is at `comment_history[(comment_id, version - 1)]` |
+| Storage burn | each edit allocates a new big_map entry sized by the *prior* content (~250 mutez/byte). For a small text comment that's a few hundred mutez; for a 32 KiB max comment it's ~8 tez. Storage burn is paid directly by the editor on top of `edit_fee`. |
+
+#### `set_own_comment_hidden(comment_id, hidden)`
+
+| | |
+|---|---|
+| Caller | original sender only |
+| Tez | exactly `hide_fee` (may be 0) |
+| Behavior | flips the `hidden` flag on caller's own comment; forwards the fee to `fee_recipient` |
+| Event | `comment_hidden_set { comment_id, hidden, updated_by }` |
+
+#### `moderate_comment_hidden(comment_id, hidden)`
+
+| | |
+|---|---|
+| Caller | any multisig user (checked via the multisig's `is_user` view); no vote required |
+| Tez | 0 |
+| Behavior | flips the `hidden` flag on any comment for fast moderation |
+| Validation | comment exists |
+| Event | `comment_moderated { comment_id, hidden, moderator }` |
+
+### Governance (multisig users only)
+
+The contract delegates user-management and quorum to the multisig at `multisig_address` via three views: `is_user`, `get_minimum_votes`, `get_expiration_time`.
+
+#### `submit_proposal(action)`
+
+`action` is a variant:
+
+| Tag | Payload | Effect on execute |
+|---|---|---|
+| `set_pause` | `bool` | sets global `paused` |
+| `set_post_fee` | `mutez` | updates `post_fee` |
+| `set_edit_fee` | `mutez` | updates `edit_fee` |
+| `set_hide_fee` | `mutez` | updates `hide_fee` |
+| `set_fee_recipient` | `address` | updates `fee_recipient` |
+| `update_multisig_address` | `address` | swaps the multisig governance contract |
+| `update_metadata` | `{key: string, value: bytes}` | writes to TZIP-16 metadata big_map |
+| `set_user_banned` | `{address: address, banned: bool}` | adds or removes an address from the contract-wide ban list (banned addresses can't `post_comment` or `edit_comment`) |
+
+Note: there is **no** `update_token_gate` action — the gate is per-call, not a contract-wide configuration. Hiding individual comments is also **not** a proposal action; see `moderate_comment_hidden` above for the direct multisig-user path.
+
+#### `vote_proposal(proposal_id, approval)`
+
+Multisig users vote yes/no. Re-voting overwrites the previous vote (the prior tally is decremented before applying the new one).
+
+#### `execute_proposal(proposal_id)`
+
+Any multisig user. Requires `positive_votes ≥ get_minimum_votes()` from the multisig and the proposal not to be expired.
+
+## Views (on-chain)
+
+| View | Returns |
+|---|---|
+| `get_comment(comment_id: nat)` | `comment` record (live version) |
+| `get_comment_version((comment_id, version): (nat, nat))` | `history_entry` record (an archived prior version). Errors with `VERSION_NOT_FOUND` if the slot is empty. |
+| `get_comment_version_count(comment_id: nat)` | `nat` — total version count (= the live `version` field). Versions start at 1, so this returns 1 for a never-edited comment and `1 + number_of_edits` otherwise. Archived snapshots live at indices `1..count-1`; the live version (index = `count`) lives in `comments[comment_id]`. |
+| `get_fees()` | `{post_fee: mutez, edit_fee: mutez, hide_fee: mutez}` |
+| `get_proposal(proposal_id: nat)` | `proposal` record |
+| `get_vote((proposal_id, voter))` | `bool` (default false) |
+| `is_banned(address: address)` | `bool` (true if the address is on the ban list) |
+
+There is **no** `get_token_gate()` view — every comment carries its own `(fa2_address, token_id)`, readable via `get_comment`.
+
+## Error codes
+
+See the module docstring at the top of [`token_comments.py`](./token_comments.py) for the full list, grouped by area:
+
+- comment ops (`CONTRACT_PAUSED`, `TEZ_TRANSFER`, `INCORRECT_FEE`, `EMPTY_CONTENT`, `CONTENT_TOO_LARGE`, `PARENT_NOT_FOUND`, `PARENT_WRONG_TOKEN`, `PARENT_HIDDEN`, `COMMENT_NOT_FOUND`, `NOT_AUTHORIZED`, `USER_BANNED`, `VERSION_NOT_FOUND`)
+- token gate / FA2 (`PENDING_POST_EXISTS`, `NO_PENDING_POST`, `INVALID_CALLBACK_SENDER`, `EMPTY_BALANCE_RESPONSE`, `NOT_TOKEN_HOLDER`, `SELF_CALLBACK_ERROR`, `INVALID_FA2`)
+- governance (`TC_VIEW_FAILED`, `TC_NOT_MULTISIG_USER`, `TC_GET_MIN_VOTES_FAILED`, `TC_GET_EXPIRATION_FAILED`, `TC_PROPOSAL_EXPIRED`, `TC_NO_PROPOSAL`, `TC_ALREADY_EXECUTED`, `TC_NOT_ENOUGH_VOTES`)
+
+`PARENT_WRONG_TOKEN` fires whenever the parent's `fa2_address` *or* `token_id` differs from the new comment's.
+
+## Indexer notes
+
+Event tags emitted by the contract:
+
+Comment lifecycle:
+- `comment_posted { fa2_address, token_id, comment_id, sender, parent_id, timestamp }` — emitted from `balance_callback` after a successful post. New posts start at `version = 1`. The `(fa2_address, token_id)` pair is the topic the comment belongs to.
+- `comment_edited { fa2_address, token_id, comment_id, sender, parent_id, timestamp, version }` — emitted after a successful edit. `timestamp` is the moment the new version became live (i.e. `sp.now` at edit time, matching the new value of `comments[comment_id].timestamp`). `version` is the new live version index; the previous version is now archived at `comment_history[(comment_id, version - 1)]`. Content lives in the `comments` / `comment_history` big_maps, not the event.
+- `comment_hidden_set { comment_id, hidden, updated_by }` — emitted by `set_own_comment_hidden`; `updated_by` is the comment's sender
+- `comment_moderated { comment_id, hidden, moderator }` — emitted by `moderate_comment_hidden`; `moderator` is the multisig user who flipped the flag
+
+Note: the hide/moderate events deliberately don't echo `(fa2_address, token_id)` since that's stable for the lifetime of the comment — re-read `comments[comment_id]` to recover it.
+
+Governance state changes emitted from `execute_proposal`:
+- `pause_set { proposal_id, paused, updated_by }`
+- `post_fee_set { proposal_id, post_fee, updated_by }`
+- `edit_fee_set { proposal_id, edit_fee, updated_by }`
+- `hide_fee_set { proposal_id, hide_fee, updated_by }`
+- `fee_recipient_set { proposal_id, fee_recipient, updated_by }`
+- `multisig_address_set { proposal_id, multisig_address, updated_by }`
+- `metadata_updated { proposal_id, key, updated_by }` — value lives in the `metadata` big_map
+- `user_banned_set { proposal_id, address, banned, updated_by }`
+
+There is **no** `token_gate_updated` event — there's no contract-wide token gate to update.
+
+`submit_proposal` and `vote_proposal` deliberately don't emit events — the `proposals` and `votes` big_maps are queryable via views and re-readable on every block. Subscribe to the per-action events above to react to executed proposals.
+
+Because `edit_comment` overwrites content in place and `comment_edited` carries no content, indexers must re-read the live comment from the `comments` big_map on edit events. The just-archived prior version is available at `comment_history[(comment_id, version - 1)]` where `version` is the new live version index emitted on the event. The full chain of versions can be reconstructed by walking indices `1..version-1` in `comment_history` plus the live `comments[comment_id]` entry. Versions start at 1.
+
+To list all comments on a specific Teia token, index on `(fa2_address, token_id)` from `comment_posted` events (or scan the `comments` big_map). The pair is also a natural grouping key for reply threads.
+
+## Deployment
+
+The file ships with two scenarios, `token_comments_deploy_shadownet` and `token_comments_deploy_mainnet`. They differ only in the multisig/fee_recipient address. There is no Teia FA2 address in storage — the gate is per-call.
+
+| Network | Multisig & fee_recipient | post_fee | edit_fee | hide_fee | metadata |
+|---|---|---|---|---|---|
+| Shadownet | `KT1KeGd4YtjcKqgyiXUPJQkm2iYA3fQwLGQP` | `25000` mutez | `0` | `0` | `ipfs://QmeNKK9t4xdeNo8NCyJtmmdEZ2p2CFzgnLyMmtoWzaCUWf` |
+| Mainnet | `KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb` | `25000` mutez | `0` | `0` | `ipfs://QmeNKK9t4xdeNo8NCyJtmmdEZ2p2CFzgnLyMmtoWzaCUWf` |
+
+To compile:
+
+```bash
+SMARTPY_OUTPUT_DIR=output/token_comments python python/contracts/messages/token_comments.py
+```
+
+To originate on Shadownet (assumes the compiled artifacts are in `output/token_comments/token_comments_deploy_shadownet/`):
+
+```bash
+STORAGE=$(cat output/token_comments/token_comments_deploy_shadownet/step_002_cont_0_storage.tz)
+octez-client --endpoint https://rpc.shadownet.teztnets.com \
+  originate contract token_comments_v1 \
+  transferring 0 from WALLET \
+  running output/token_comments/token_comments_deploy_shadownet/step_002_cont_0_contract.tz \
+  --init "$STORAGE" --burn-cap 5
+```
+
+Same shape on mainnet, swap the endpoint to `https://mainnet.api.tez.ie` and point at the `token_comments_deploy_mainnet` artifacts.
+
+| Network | Address | Alias | Notes |
+|---|---|---|---|
+| Mainnet | `KT1FXFxUcZvne1ApoSaeZfvmDR73u2BsuFUP` | `token_comments_mainnet_v1` | post=25000 / edit=0 / hide=0, metadata pinned at `ipfs://QmeNKK9t4xdeNo8NCyJtmmdEZ2p2CFzgnLyMmtoWzaCUWf` |
+| Shadownet | `KT1BGBMUQK6rvLvbrrPEMdeLGAWr2ymSmw73` | `token_comments_v1` | same config; originally deployed with placeholder metadata `ipfs://aaa`, swap via `update_metadata` proposal if you want to point it at the pinned CID |

--- a/python/contracts/wiki/wiki.md
+++ b/python/contracts/wiki/wiki.md
@@ -1,0 +1,200 @@
+# Wiki Contract
+
+An on-chain registry for the **Teia community wiki**. Each page is identified
+solely by an auto-incrementing integer `page_id` and stores its current IPFS/Arweave
+**CID**, a `hidden` flag, and a full, append-only **version history**. Page
+names/titles live off-chain inside the CID content, duplicate-name checks are the UI's
+responsibility.
+
+**Moderators** and **multisig users** can create, update, and hide pages directly, while
+**Teia token holders** can submit proposals to edit an existing page or create a brand new
+one. Governance (pause, linked addresses, fees, metadata) runs through the linked **Teia
+multisig**.
+
+## What it does
+
+- Stores pages keyed by an auto-incrementing `page_id` (never deleted, so the id also
+  enumerates every page), each with its `current_cid`, `hidden` flag, and `version_count`.
+- Keeps the full version history per page in `versions`, keyed by `(page_id, version)`,
+  every version records its CID, editor, optional proposer, and timestamp.
+- Lets **moderators / multisig users** create, update, and hide pages directly.
+- Lets **Teia token holders** propose an edit to an existing page (`create_proposal`) or a
+  brand new page (`prop_new_page`); a single moderator/multisig approval applies it.
+- Charges a per-action fee on the two community-proposal entrypoints (both default to 0,
+  free) and forwards it to `fee_recipient`.
+- Routes all config changes through a **governance** propose → vote → execute flow gated on
+  the multisig, with the **minimum vote threshold** and **expiration time** fetched live
+  from the multisig contract rather than stored locally.
+
+## Storage
+
+| Field               | Type                                       | Meaning                                                    |
+| ------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `metadata`          | `big_map[string, bytes]`                   | TZIP-16 contract metadata.                                 |
+| `moderator_address` | `address`                                  | Linked moderator contract (read via its `is_moderator` view). |
+| `multisig_address`  | `address`                                  | The Teia multisig that governs this contract.              |
+| `token_address`     | `address`                                  | Teia DAO token FA2 (read via its `get_balance` view).      |
+| `token_id`          | `nat`                                      | Token id whose holders may submit proposals.               |
+| `paused`            | `bool`                                     | Global pause flag (governance-set).                        |
+| `fee_recipient`     | `address`                                  | Where per-action fees are forwarded.                       |
+| `propose_edit_fee`  | `mutez`                                    | Fee attached to `create_proposal` (0 = free).              |
+| `propose_page_fee`  | `mutez`                                    | Fee attached to `prop_new_page` (0 = free).                |
+| `pages`             | `big_map[nat, page]`                       | Page records by id.                                        |
+| `versions`          | `big_map[(page_id, version), version]`     | Full version history per page.                             |
+| `page_count`        | `nat`                                      | Next page id / total pages.                                |
+| `proposals`         | `big_map[nat, proposal]`                   | Community (token-holder) proposals by id.                  |
+| `proposal_counter`  | `nat`                                      | Next community proposal id (auto-incrementing).            |
+| `gov_proposals`     | `big_map[nat, gov_proposal]`               | Governance proposals by id.                                |
+| `gov_votes`         | `big_map[(nat, address), bool]`            | A voter's current vote per governance proposal.            |
+| `gov_counter`       | `nat`                                      | Next governance proposal id (auto-incrementing).           |
+
+A `page` records its `current_cid`, `hidden` flag, and `version_count`.
+
+A `version` records its `cid`, `editor`, optional `proposer` (set when the version came
+from an approved community proposal), `ts`, and `version` index.
+
+A `proposal` records its `target` (`edit(page_id)` or `new_page`), `proposed_cid`,
+`proposer`, `status` (0 = pending, 1 = approved, 2 = rejected), `created_at`, and the
+`resolved_by` / `resolved_at` fields (None while pending, set on approval/rejection).
+
+A `gov_proposal` records its `action`, `executed` flag, `issuer`, `timestamp`,
+`positive_votes`, and `negative_votes`.
+
+## Who can do what
+
+- **Moderators or multisig users** (moderator checked via the moderator contract's
+  `is_moderator` view; multisig user checked via the multisig's `is_user` view — the
+  multisig is checked first so a misconfigured moderator address can't lock multisig users
+  out) may `create_page`, `update_page`, `set_page_hidden`, `approve_proposal`, and
+  `reject_proposal`.
+- **Teia token holders** (balance > 0 at `token_id`, verified live via the token's
+  `get_balance` view) may `create_proposal` and `prop_new_page`, attaching exactly the
+  matching fee.
+- **Multisig users only** may `submit_governance_proposal`, `vote_governance_proposal`, and
+  `execute_governance_proposal`.
+- Anyone failing the relevant check is rejected with `WIKI_NOT_AUTHORIZED` (or `WIKI_NO_TOKENS`
+  for the proposal entrypoints).
+
+## Interaction flow
+
+Direct moderation is a single call, `create_page` / `update_page` / `set_page_hidden` by a
+moderator or multisig user applies immediately. The community path adds a review step:
+
+```
+token holder                 moderator / multisig user
+     │                                 │
+ create_proposal / prop_new_page       │
+ (holds token, pays fee)  ──►  proposal stored, status = pending
+     │                                 │
+     │                approve_proposal ─► status = approved,
+     │                                    edit → new version appended,
+     │                                    new_page → page created + id assigned
+     │                                 │
+     │                 reject_proposal ─► status = rejected (kept on-chain)
+```
+
+Config changes use the governance flow, `submit_governance_proposal` → one or more
+`vote_governance_proposal` → `execute_governance_proposal` once `positive_votes >=
+minimum_votes` and the proposal has not expired.
+
+### Page entrypoints (moderators / multisig users)
+
+- `create_page(cid)` — registers a new page at the next integer id, seeds version 1. Emits
+  `page_created`.
+- `update_page({page_id, cid})` — appends a new version and updates `current_cid`. Emits
+  `page_updated`.
+- `set_page_hidden({page_id, hidden})` — flips the `hidden` flag. Emits `page_hidden_updated`.
+
+### Community proposal entrypoints (Teia token holders)
+
+- `create_proposal({page_id, proposed_cid})` — proposes editing an existing page; requires
+  exactly `propose_edit_fee`. Emits `proposal_created` (`is_new_page = false`).
+- `prop_new_page(cid)` — proposes a brand new page (the id is assigned only on approval);
+  requires exactly `propose_page_fee`. Emits `proposal_created` (`is_new_page = true`).
+- `approve_proposal(proposal_id)` — moderator/multisig user; applies the change. An `edit`
+  appends a new version to the page; a `new_page` creates the page with a fresh id. Emits
+  `page_created`/`page_updated` where relevant plus `proposal_approved`.
+- `reject_proposal(proposal_id)` — moderator/multisig user; sets status to rejected. The
+  proposal record stays on-chain for transparency. Emits `proposal_rejected`.
+
+Both approve and reject require the proposal to still be pending, else `WIKI_ALREADY_RESOLVED`.
+
+### Governance entrypoints (multisig users)
+
+`submit_governance_proposal(action)` creates a proposal, `action` is a variant, exactly one
+of:
+
+| Variant                  | Payload          | Effect on execution                          |
+| ------------------------ | ---------------- | -------------------------------------------- |
+| `set_pause`              | `bool`           | Sets the global `paused` flag.               |
+| `set_multisig_address`   | `address`        | Re-points governance to a new multisig.      |
+| `set_moderator_address`  | `address`        | Re-points the linked moderator contract.     |
+| `set_token_address`      | `address`        | Changes the gating token FA2 contract.       |
+| `set_token_id`           | `nat`            | Changes the gating token id.                 |
+| `set_fee_recipient`      | `address`        | Changes where fees are forwarded.            |
+| `set_propose_edit_fee`   | `mutez`          | Sets the `create_proposal` fee.              |
+| `set_propose_page_fee`   | `mutez`          | Sets the `prop_new_page` fee.                |
+| `update_metadata`        | `{key, value}`   | Writes one metadata entry (`bytes`).         |
+
+`vote_governance_proposal({proposal_id, approval})` casts (or changes) the sender's vote, a
+previous vote is subtracted before the new one is applied, so the tallies always reflect
+current standing. Voting on an executed proposal fails (`WIKI_GOV_ALREADY_EXECUTED`), and
+voting past the expiration window fails (`WIKI_GOV_EXPIRED`).
+
+`execute_governance_proposal(proposal_id)` applies the action. Requires `positive_votes >=
+minimum_votes` (else `WIKI_GOV_NOT_ENOUGH_VOTES`), not already executed (else
+`WIKI_GOV_ALREADY_EXECUTED`), and not expired (else `WIKI_GOV_EXPIRED`).
+
+## Views (read-only, callable on-chain by other contracts)
+
+| View                     | Input               | Returns                                        | Use                                          |
+| ------------------------ | ------------------- | ---------------------------------------------- | -------------------------------------------- |
+| `get_page`               | `nat`               | `page`                                         | Read a page's current CID / hidden / count.  |
+| `get_version`            | `(page_id, version)`| `version`                                      | Read one historical version.                 |
+| `get_page_count`         | —                   | `nat`                                          | Total number of pages.                       |
+| `get_proposal`           | `nat`               | `proposal`                                     | Inspect a community proposal.                |
+| `get_proposal_count`     | —                   | `nat`                                          | Total number of community proposals.         |
+| `get_fees`               | —                   | `{propose_edit_fee, propose_page_fee, fee_recipient}` | Current per-action fees and recipient. |
+| `get_governance_proposal`| `nat`               | `gov_proposal`                                 | Inspect a governance proposal.               |
+| `get_governance_vote`    | `(nat, address)`    | `bool` (default `false`)                       | A voter's current vote on a gov proposal.    |
+
+`get_page`, `get_version`, `get_proposal`, and `get_governance_proposal` fail if the id/key
+is unknown (see the error reference).
+
+## Dependency on the multisig (and other contracts)
+
+The contract reads several external on-chain views; if any is missing or fails, the
+corresponding entrypoint reverts:
+
+- **Multisig** at `multisig_address`:
+  - `is_user(address) → bool` — gate on moderation and governance entrypoints.
+  - `get_minimum_votes() → nat` — vote threshold, read at governance execution.
+  - `get_expiration_time() → nat` (days) — proposal lifetime, read when voting/executing.
+- **Moderator** at `moderator_address`:
+  - `is_moderator(address) → bool` — checked after the multisig for moderation entrypoints.
+- **Token** at `token_address`:
+  - `get_balance({owner, token_id}) → nat` — verifies a proposer holds the Teia token.
+
+## Error reference
+
+| Error                        | Cause                                                        |
+| ---------------------------- | ----------------------------------------------------------- |
+| `WIKI_NOT_AUTHORIZED`        | Caller is not a moderator / multisig user for this action.  |
+| `WIKI_PAUSED`                | Contract is paused.                                         |
+| `WIKI_TEZ_TRANSFER`          | Tez attached to an entrypoint that expects none.            |
+| `WIKI_INCORRECT_FEE`         | Attached amount does not match the action fee.              |
+| `WIKI_EMPTY_CID`             | CID cannot be empty.                                        |
+| `WIKI_PAGE_NOT_FOUND`        | No page found for this page id.                             |
+| `WIKI_VERSION_NOT_FOUND`     | No version found for this `(page_id, version)`.             |
+| `WIKI_NO_PROPOSAL`           | Community proposal id does not exist.                       |
+| `WIKI_ALREADY_RESOLVED`      | Community proposal was already approved or rejected.        |
+| `WIKI_NO_TOKENS`             | Caller does not hold the Teia token.                        |
+| `WIKI_NO_GOV_PROPOSAL`       | Governance proposal id does not exist.                      |
+| `WIKI_GOV_ALREADY_EXECUTED`  | Governance proposal already executed.                       |
+| `WIKI_GOV_NOT_ENOUGH_VOTES`  | `positive_votes < minimum_votes`.                           |
+| `WIKI_GOV_EXPIRED`           | Past the multisig's expiration window.                      |
+| `WIKI_MULTISIG_VIEW_FAILED`  | Multisig `is_user` view failed.                             |
+| `WIKI_MODERATOR_VIEW_FAILED` | Moderator `is_moderator` view failed.                       |
+| `WIKI_TOKEN_VIEW_FAILED`     | Token `get_balance` view failed.                            |
+| `WIKI_GET_MIN_VOTES_FAILED`  | Multisig `get_minimum_votes` view failed.                   |
+| `WIKI_GET_EXPIRATION_FAILED` | Multisig `get_expiration_time` view failed.                 |

--- a/python/contracts/wiki/wiki.py
+++ b/python/contracts/wiki/wiki.py
@@ -1,0 +1,1081 @@
+import smartpy as sp
+
+
+@sp.module
+def wiki_module():
+    """Teia Wiki Contract.
+
+    Each page is identified on-chain solely by an auto-incrementing
+    integer ``page_id``. Page names/titles live off-chain in the page's
+    IPFS/Arweave content; the contract stores only the current CID, the hidden
+    flag and the full version history per page. Duplicate-name checks are the
+    UI's responsibility. Token holders can propose page edits; moderators and
+    multisig users can approve, reject, create, and update pages directly.
+
+    Access control:
+    - create_page: moderators and multisig users
+    - update_page: moderators and multisig users
+    - set_page_hidden: moderators and multisig users
+    - create_proposal: Teia token holders (propose an edit to an existing page)
+    - prop_new_page: Teia token holders (propose a brand new page)
+    - approve_proposal / reject_proposal: moderators and multisig users
+    - governance (pause, addresses, fees, metadata): multisig vote required
+
+    Per-action fees:
+    - create_proposal charges propose_edit_fee, prop_new_page charges
+      propose_page_fee. Both default to 0 (free) and are forwarded to
+      fee_recipient. Each fee (and fee_recipient) is changed only through a
+      governance proposal, matching the channels / comment contracts.
+
+    Error codes:
+    - WIKI_NOT_AUTHORIZED: Caller is not authorized for this action
+    - WIKI_PAGE_NOT_FOUND: No page found for this page id
+    - WIKI_VERSION_NOT_FOUND: No version found for this (page id, version)
+    - WIKI_EMPTY_CID: CID cannot be empty
+    - WIKI_PAUSED: Contract is paused
+    - WIKI_TEZ_TRANSFER: Unexpected tez transfer
+    - WIKI_INCORRECT_FEE: Attached amount does not match the action fee
+    - WIKI_NO_PROPOSAL: Proposal ID does not exist
+    - WIKI_ALREADY_RESOLVED: Proposal has already been approved or rejected
+    - WIKI_NO_TOKENS: Caller does not hold Teia tokens
+    - WIKI_NO_GOV_PROPOSAL: Governance proposal ID does not exist
+    - WIKI_GOV_ALREADY_EXECUTED: Governance proposal already executed
+    - WIKI_GOV_NOT_ENOUGH_VOTES: Not enough votes to execute
+    - WIKI_GOV_EXPIRED: Governance proposal has expired
+    """
+
+    # =========================================================================
+    # Types
+    # =========================================================================
+
+    version_type: type = sp.record(
+        cid=sp.string,
+        editor=sp.address,
+        proposer=sp.option[sp.address],
+        ts=sp.timestamp,
+        version=sp.nat,
+    ).layout(("cid", ("editor", ("proposer", ("ts", "version")))))
+
+    # Versions are keyed by the integer page id.
+    version_key_type: type = sp.record(
+        page_id=sp.nat,
+        version=sp.nat,
+    )
+
+    page_type: type = sp.record(
+        current_cid=sp.string,
+        hidden=sp.bool,
+        version_count=sp.nat,
+    ).layout(("current_cid", ("hidden", "version_count")))
+
+    # Entrypoint parameter types
+    update_page_params_type: type = sp.record(
+        page_id=sp.nat,
+        cid=sp.string,
+    ).layout(("page_id", "cid"))
+
+    set_page_hidden_params_type: type = sp.record(
+        page_id=sp.nat,
+        hidden=sp.bool,
+    ).layout(("page_id", "hidden"))
+
+    # Community proposal types (token holders propose page edits or new pages)
+    # Status: 0 = pending, 1 = approved, 2 = rejected
+    # target.edit(page_id) -> proposes editing an existing page
+    # target.new_page()    -> proposes creating a brand new page (the id is
+    #                         assigned once the proposal is approved)
+    proposal_target_type: type = sp.variant(
+        edit=sp.nat,
+        new_page=sp.unit,
+    )
+
+    # resolved_by / resolved_at are None while pending (status 0) and set to
+    # the approver/rejecter and the resolution time when the proposal is
+    # approved (status 1) or rejected (status 2).
+    proposal_type: type = sp.record(
+        target=proposal_target_type,
+        proposed_cid=sp.string,
+        proposer=sp.address,
+        status=sp.nat,
+        created_at=sp.timestamp,
+        resolved_by=sp.option[sp.address],
+        resolved_at=sp.option[sp.timestamp],
+    ).layout(
+        (
+            "target",
+            (
+                "proposed_cid",
+                (
+                    "proposer",
+                    ("status", ("created_at", ("resolved_by", "resolved_at"))),
+                ),
+            ),
+        )
+    )
+
+    create_proposal_params_type: type = sp.record(
+        page_id=sp.nat,
+        proposed_cid=sp.string,
+    ).layout(("page_id", "proposed_cid"))
+
+    # Governance types (config changes require multisig vote)
+    metadata_entry_type: type = sp.record(
+        key=sp.string,
+        value=sp.bytes,
+    ).layout(("key", "value"))
+
+    gov_action_type: type = sp.variant(
+        set_pause=sp.bool,
+        set_multisig_address=sp.address,
+        set_moderator_address=sp.address,
+        set_token_address=sp.address,
+        set_token_id=sp.nat,
+        set_fee_recipient=sp.address,
+        set_propose_edit_fee=sp.mutez,
+        set_propose_page_fee=sp.mutez,
+        update_metadata=metadata_entry_type,
+    )
+
+    gov_proposal_type: type = sp.record(
+        action=gov_action_type,
+        executed=sp.bool,
+        issuer=sp.address,
+        timestamp=sp.timestamp,
+        positive_votes=sp.nat,
+        negative_votes=sp.nat,
+    ).layout(
+        (
+            "action",
+            (
+                "executed",
+                (
+                    "issuer",
+                    ("timestamp", ("positive_votes", "negative_votes")),
+                ),
+            ),
+        )
+    )
+
+    gov_vote_key_type: type = sp.pair[sp.nat, sp.address]
+
+    gov_vote_params_type: type = sp.record(
+        proposal_id=sp.nat,
+        approval=sp.bool,
+    ).layout(("proposal_id", "approval"))
+
+    # =========================================================================
+    # Contract
+    # =========================================================================
+
+    class Wiki(sp.Contract):
+        def __init__(
+            self,
+            metadata,
+            moderator_address,
+            multisig_address,
+            token_address,
+            token_id,
+            fee_recipient,
+            propose_edit_fee,
+            propose_page_fee,
+            pages,
+            versions,
+            page_count,
+            gov_counter,
+        ):
+            self.data.metadata = sp.cast(
+                metadata, sp.big_map[sp.string, sp.bytes]
+            )
+            self.data.moderator_address = sp.cast(
+                moderator_address, sp.address
+            )
+            self.data.multisig_address = sp.cast(
+                multisig_address, sp.address
+            )
+            self.data.token_address = sp.cast(token_address, sp.address)
+            self.data.token_id = sp.cast(token_id, sp.nat)
+            self.data.paused = False
+
+            # Per-action fees (forwarded to fee_recipient; 0 = free)
+            self.data.fee_recipient = sp.cast(fee_recipient, sp.address)
+            self.data.propose_edit_fee = sp.cast(propose_edit_fee, sp.mutez)
+            self.data.propose_page_fee = sp.cast(propose_page_fee, sp.mutez)
+
+            # Page storage. Pages are keyed by an auto-incrementing integer id
+            # (0..page_count-1, never deleted, so the id also enumerates pages).
+            # Seeded at origination from the previous contract's pages/versions
+            # (pass empty big_maps and page_count 0 for a fresh deployment).
+            self.data.pages = sp.cast(pages, sp.big_map[sp.nat, page_type])
+            self.data.versions = sp.cast(
+                versions, sp.big_map[version_key_type, version_type]
+            )
+            self.data.page_count = sp.cast(page_count, sp.nat)
+
+            # Community proposal storage
+            self.data.proposals = sp.cast(
+                sp.big_map(), sp.big_map[sp.nat, proposal_type]
+            )
+            self.data.proposal_counter = sp.cast(sp.nat(0), sp.nat)
+
+            # Governance storage
+            self.data.gov_proposals = sp.cast(
+                sp.big_map(), sp.big_map[sp.nat, gov_proposal_type]
+            )
+            self.data.gov_votes = sp.cast(
+                sp.big_map(), sp.big_map[gov_vote_key_type, sp.bool]
+            )
+            self.data.gov_counter = sp.cast(gov_counter, sp.nat)
+
+        # =====================================================================
+        # Helper Methods
+        # =====================================================================
+
+        @sp.private(with_storage="read-only")
+        def _check_not_paused(self):
+            assert not self.data.paused, "WIKI_PAUSED"
+
+        @sp.private(with_storage="read-only")
+        def _check_no_tez_transfer(self):
+            assert sp.amount == sp.tez(0), "WIKI_TEZ_TRANSFER"
+
+        @sp.private(with_storage="read-only")
+        def _check_is_multisig_user(self):
+            """Checks that the sender is a multisig user."""
+            is_user = sp.view(
+                "is_user",
+                self.data.multisig_address,
+                sp.sender,
+                sp.bool,
+            ).unwrap_some(error="WIKI_MULTISIG_VIEW_FAILED")
+            assert is_user, "WIKI_NOT_AUTHORIZED"
+
+        @sp.private(with_storage="read-only")
+        def _check_is_moderator_or_multisig(self):
+            """Checks that the sender is a moderator or multisig user.
+
+            The multisig view is checked first so that a misconfigured
+            moderator_address cannot lock multisig users out of the
+            moderation entrypoints.
+            """
+            authorized = sp.view(
+                "is_user",
+                self.data.multisig_address,
+                sp.sender,
+                sp.bool,
+            ).unwrap_some(error="WIKI_MULTISIG_VIEW_FAILED")
+
+            if not authorized:
+                authorized = sp.view(
+                    "is_moderator",
+                    self.data.moderator_address,
+                    sp.sender,
+                    sp.bool,
+                ).unwrap_some(error="WIKI_MODERATOR_VIEW_FAILED")
+
+            assert authorized, "WIKI_NOT_AUTHORIZED"
+
+        @sp.private(with_storage="read-only")
+        def _get_minimum_votes(self):
+            return sp.view(
+                "get_minimum_votes",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="WIKI_GET_MIN_VOTES_FAILED")
+
+        @sp.private(with_storage="read-only")
+        def _check_not_expired(self, timestamp):
+            expiration_days = sp.view(
+                "get_expiration_time",
+                self.data.multisig_address,
+                (),
+                sp.nat,
+            ).unwrap_some(error="WIKI_GET_EXPIRATION_FAILED")
+
+            expiration_seconds = sp.to_int(expiration_days * 86400)
+            expiration_time = sp.add_seconds(timestamp, expiration_seconds)
+            assert not (sp.now > expiration_time), "WIKI_GOV_EXPIRED"
+
+        @sp.private(with_storage="read-only")
+        def _check_has_tokens(self):
+            """Checks that the sender holds Teia tokens (balance > 0)."""
+            balance = sp.view(
+                "get_balance",
+                self.data.token_address,
+                sp.record(owner=sp.sender, token_id=self.data.token_id),
+                sp.nat,
+            ).unwrap_some(error="WIKI_TOKEN_VIEW_FAILED")
+            assert balance > 0, "WIKI_NO_TOKENS"
+
+        @sp.private(with_storage="read-only", with_operations=True)
+        def _send_fee(self, fee):
+            """Forwards the fee to fee_recipient (only when greater than 0)."""
+            if fee > sp.mutez(0):
+                sp.send(self.data.fee_recipient, fee)
+
+        # =====================================================================
+        # Page Entrypoints
+        # =====================================================================
+
+        @sp.entrypoint
+        def create_page(self, cid):
+            """Register a new page with its initial CID.
+
+            Moderators and multisig users can create pages. The page is
+            assigned the next integer id. The page name/title lives off-chain
+            in the CID content.
+            """
+            sp.cast(cid, sp.string)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_is_moderator_or_multisig()
+
+            assert sp.len(cid) > 0, "WIKI_EMPTY_CID"
+
+            page_id = self.data.page_count
+
+            self.data.pages[page_id] = sp.record(
+                current_cid=cid,
+                hidden=False,
+                version_count=sp.nat(1),
+            )
+
+            self.data.versions[
+                sp.record(page_id=page_id, version=sp.nat(1))
+            ] = sp.record(
+                cid=cid,
+                editor=sp.sender,
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.now,
+                version=sp.nat(1),
+            )
+
+            self.data.page_count += 1
+
+            sp.emit(
+                sp.record(
+                    page_id=page_id,
+                    cid=cid,
+                    hidden=False,
+                    editor=sp.sender,
+                    timestamp=sp.now,
+                ),
+                tag="page_created",
+            )
+
+        @sp.entrypoint
+        def update_page(self, params):
+            """Update the current CID for an existing page.
+
+            Only moderators and multisig users can update pages directly.
+            Pages are addressed by their integer id.
+            """
+            sp.cast(params, update_page_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_is_moderator_or_multisig()
+
+            assert sp.len(params.cid) > 0, "WIKI_EMPTY_CID"
+            assert params.page_id in self.data.pages, "WIKI_PAGE_NOT_FOUND"
+
+            page = self.data.pages[params.page_id]
+            new_version = page.version_count + 1
+
+            self.data.versions[
+                sp.record(page_id=params.page_id, version=new_version)
+            ] = sp.record(
+                cid=params.cid,
+                editor=sp.sender,
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.now,
+                version=new_version,
+            )
+
+            self.data.pages[params.page_id] = sp.record(
+                current_cid=params.cid,
+                hidden=page.hidden,
+                version_count=new_version,
+            )
+
+            sp.emit(
+                sp.record(
+                    page_id=params.page_id,
+                    cid=params.cid,
+                    hidden=page.hidden,
+                    version=new_version,
+                    editor=sp.sender,
+                    proposer=sp.cast(None, sp.option[sp.address]),
+                    timestamp=sp.now,
+                ),
+                tag="page_updated",
+            )
+
+        @sp.entrypoint
+        def set_page_hidden(self, params):
+            """Set the hidden flag on a page.
+
+            Only moderators and multisig users can hide/unhide pages.
+            Pages are addressed by their integer id.
+            """
+            sp.cast(params, set_page_hidden_params_type)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_is_moderator_or_multisig()
+
+            assert params.page_id in self.data.pages, "WIKI_PAGE_NOT_FOUND"
+
+            page = self.data.pages[params.page_id]
+            self.data.pages[params.page_id] = sp.record(
+                current_cid=page.current_cid,
+                hidden=params.hidden,
+                version_count=page.version_count,
+            )
+
+            sp.emit(
+                sp.record(
+                    page_id=params.page_id,
+                    hidden=params.hidden,
+                    editor=sp.sender,
+                    timestamp=sp.now,
+                ),
+                tag="page_hidden_updated",
+            )
+
+        # =====================================================================
+        # Community Proposal Entrypoints
+        # =====================================================================
+
+        @sp.entrypoint
+        def create_proposal(self, params):
+            """Submit a draft CID to edit an existing page.
+
+            Caller must hold Teia tokens and attach exactly propose_edit_fee.
+            The page is addressed by its integer id.
+            """
+            sp.cast(params, create_proposal_params_type)
+            self._check_not_paused()
+            assert sp.amount == self.data.propose_edit_fee, "WIKI_INCORRECT_FEE"
+            self._check_has_tokens()
+
+            assert sp.len(params.proposed_cid) > 0, "WIKI_EMPTY_CID"
+            assert params.page_id in self.data.pages, "WIKI_PAGE_NOT_FOUND"
+
+            self._send_fee(sp.amount)
+
+            proposal_id = self.data.proposal_counter
+            self.data.proposals[proposal_id] = sp.record(
+                target=sp.variant.edit(params.page_id),
+                proposed_cid=params.proposed_cid,
+                proposer=sp.sender,
+                status=sp.nat(0),
+                created_at=sp.now,
+                resolved_by=sp.cast(None, sp.option[sp.address]),
+                resolved_at=sp.cast(None, sp.option[sp.timestamp]),
+            )
+            self.data.proposal_counter += 1
+
+            sp.emit(
+                sp.record(
+                    proposal_id=proposal_id,
+                    page_id=sp.Some(params.page_id),
+                    proposed_cid=params.proposed_cid,
+                    proposer=sp.sender,
+                    is_new_page=False,
+                    timestamp=sp.now,
+                ),
+                tag="proposal_created",
+            )
+
+        @sp.entrypoint
+        def prop_new_page(self, cid):
+            """Propose the creation of a brand new page.
+
+            Caller must hold Teia tokens and attach exactly propose_page_fee.
+            The page is only created (and assigned an id) once a
+            moderator/multisig user approves the proposal.
+            """
+            sp.cast(cid, sp.string)
+            self._check_not_paused()
+            assert sp.amount == self.data.propose_page_fee, "WIKI_INCORRECT_FEE"
+            self._check_has_tokens()
+
+            assert sp.len(cid) > 0, "WIKI_EMPTY_CID"
+
+            self._send_fee(sp.amount)
+
+            proposal_id = self.data.proposal_counter
+            self.data.proposals[proposal_id] = sp.record(
+                target=sp.variant.new_page(()),
+                proposed_cid=cid,
+                proposer=sp.sender,
+                status=sp.nat(0),
+                created_at=sp.now,
+                resolved_by=sp.cast(None, sp.option[sp.address]),
+                resolved_at=sp.cast(None, sp.option[sp.timestamp]),
+            )
+            self.data.proposal_counter += 1
+
+            sp.emit(
+                sp.record(
+                    proposal_id=proposal_id,
+                    page_id=sp.cast(None, sp.option[sp.nat]),
+                    proposed_cid=cid,
+                    proposer=sp.sender,
+                    is_new_page=True,
+                    timestamp=sp.now,
+                ),
+                tag="proposal_created",
+            )
+
+        @sp.entrypoint
+        def approve_proposal(self, proposal_id):
+            """Approve a pending proposal and apply it to the wiki.
+
+            Only moderators or multisig users can approve. Sets status to 1
+            (approved). For an edit proposal this appends a new version to the
+            existing page; for a new-page proposal this creates the page and
+            assigns it the next integer id.
+            """
+            sp.cast(proposal_id, sp.nat)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_is_moderator_or_multisig()
+
+            assert proposal_id in self.data.proposals, "WIKI_NO_PROPOSAL"
+
+            proposal = self.data.proposals[proposal_id]
+            assert proposal.status == 0, "WIKI_ALREADY_RESOLVED"
+
+            proposal.status = sp.nat(1)
+            proposal.resolved_by = sp.Some(sp.sender)
+            proposal.resolved_at = sp.Some(sp.now)
+            self.data.proposals[proposal_id] = proposal
+
+            if proposal.target.is_variant.new_page():
+                # Create the proposed page with a fresh integer id.
+                page_id = self.data.page_count
+
+                self.data.pages[page_id] = sp.record(
+                    current_cid=proposal.proposed_cid,
+                    hidden=False,
+                    version_count=sp.nat(1),
+                )
+
+                self.data.versions[
+                    sp.record(page_id=page_id, version=sp.nat(1))
+                ] = sp.record(
+                    cid=proposal.proposed_cid,
+                    editor=sp.sender,
+                    proposer=sp.Some(proposal.proposer),
+                    ts=sp.now,
+                    version=sp.nat(1),
+                )
+
+                self.data.page_count += 1
+
+                sp.emit(
+                    sp.record(
+                        page_id=page_id,
+                        cid=proposal.proposed_cid,
+                        hidden=False,
+                        editor=sp.sender,
+                        timestamp=sp.now,
+                    ),
+                    tag="page_created",
+                )
+
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        page_id=page_id,
+                        proposed_cid=proposal.proposed_cid,
+                        is_new_page=True,
+                        approved_by=sp.sender,
+                        timestamp=sp.now,
+                    ),
+                    tag="proposal_approved",
+                )
+            else:
+                # Append a new version to the existing page.
+                page_id = proposal.target.unwrap.edit()
+                assert page_id in self.data.pages, "WIKI_PAGE_NOT_FOUND"
+
+                page = self.data.pages[page_id]
+                new_version = page.version_count + 1
+
+                self.data.versions[
+                    sp.record(page_id=page_id, version=new_version)
+                ] = sp.record(
+                    cid=proposal.proposed_cid,
+                    editor=sp.sender,
+                    proposer=sp.Some(proposal.proposer),
+                    ts=sp.now,
+                    version=new_version,
+                )
+
+                self.data.pages[page_id] = sp.record(
+                    current_cid=proposal.proposed_cid,
+                    hidden=page.hidden,
+                    version_count=new_version,
+                )
+
+                sp.emit(
+                    sp.record(
+                        proposal_id=proposal_id,
+                        page_id=page_id,
+                        proposed_cid=proposal.proposed_cid,
+                        is_new_page=False,
+                        approved_by=sp.sender,
+                        timestamp=sp.now,
+                    ),
+                    tag="proposal_approved",
+                )
+
+        @sp.entrypoint
+        def reject_proposal(self, proposal_id):
+            """Reject a pending proposal.
+
+            Only moderators or multisig users can reject.
+            Sets status to 2 (rejected). The proposal data remains on-chain
+            for transparency.
+            """
+            sp.cast(proposal_id, sp.nat)
+            self._check_not_paused()
+            self._check_no_tez_transfer()
+            self._check_is_moderator_or_multisig()
+
+            assert proposal_id in self.data.proposals, "WIKI_NO_PROPOSAL"
+
+            proposal = self.data.proposals[proposal_id]
+            assert proposal.status == 0, "WIKI_ALREADY_RESOLVED"
+
+            proposal.status = sp.nat(2)
+            proposal.resolved_by = sp.Some(sp.sender)
+            proposal.resolved_at = sp.Some(sp.now)
+            self.data.proposals[proposal_id] = proposal
+
+            sp.emit(
+                sp.record(
+                    proposal_id=proposal_id,
+                    rejected_by=sp.sender,
+                    timestamp=sp.now,
+                ),
+                tag="proposal_rejected",
+            )
+
+        # =====================================================================
+        # Governance Entrypoints
+        # =====================================================================
+
+        @sp.entrypoint
+        def submit_governance_proposal(self, action):
+            """Submit a new governance proposal for config changes."""
+            sp.cast(action, gov_action_type)
+            self._check_is_multisig_user()
+
+            self.data.gov_proposals[self.data.gov_counter] = sp.record(
+                action=action,
+                executed=False,
+                issuer=sp.sender,
+                timestamp=sp.now,
+                positive_votes=sp.nat(0),
+                negative_votes=sp.nat(0),
+            )
+            self.data.gov_counter += 1
+
+        @sp.entrypoint
+        def vote_governance_proposal(self, vote):
+            """Vote on an existing governance proposal."""
+            sp.cast(vote, gov_vote_params_type)
+
+            self._check_is_multisig_user()
+            assert vote.proposal_id in self.data.gov_proposals, "WIKI_NO_GOV_PROPOSAL"
+
+            proposal = self.data.gov_proposals[vote.proposal_id]
+            assert not proposal.executed, "WIKI_GOV_ALREADY_EXECUTED"
+            self._check_not_expired(proposal.timestamp)
+
+            vote_key = (vote.proposal_id, sp.sender)
+
+            if vote_key in self.data.gov_votes:
+                if self.data.gov_votes[vote_key]:
+                    proposal.positive_votes = sp.as_nat(
+                        proposal.positive_votes - 1
+                    )
+                else:
+                    proposal.negative_votes = sp.as_nat(
+                        proposal.negative_votes - 1
+                    )
+
+            if vote.approval:
+                proposal.positive_votes += 1
+            else:
+                proposal.negative_votes += 1
+
+            self.data.gov_votes[vote_key] = vote.approval
+            self.data.gov_proposals[vote.proposal_id] = proposal
+
+        @sp.entrypoint
+        def execute_governance_proposal(self, proposal_id):
+            """Execute an approved governance proposal."""
+            sp.cast(proposal_id, sp.nat)
+
+            self._check_is_multisig_user()
+            assert proposal_id in self.data.gov_proposals, "WIKI_NO_GOV_PROPOSAL"
+
+            proposal = self.data.gov_proposals[proposal_id]
+            assert not proposal.executed, "WIKI_GOV_ALREADY_EXECUTED"
+            minimum_votes = self._get_minimum_votes()
+            assert proposal.positive_votes >= minimum_votes, "WIKI_GOV_NOT_ENOUGH_VOTES"
+            self._check_not_expired(proposal.timestamp)
+
+            proposal.executed = True
+            self.data.gov_proposals[proposal_id] = proposal
+
+            if proposal.action.is_variant.set_pause():
+                self.data.paused = proposal.action.unwrap.set_pause()
+
+            if proposal.action.is_variant.set_multisig_address():
+                self.data.multisig_address = (
+                    proposal.action.unwrap.set_multisig_address()
+                )
+
+            if proposal.action.is_variant.set_moderator_address():
+                self.data.moderator_address = (
+                    proposal.action.unwrap.set_moderator_address()
+                )
+
+            if proposal.action.is_variant.set_token_address():
+                self.data.token_address = (
+                    proposal.action.unwrap.set_token_address()
+                )
+
+            if proposal.action.is_variant.set_token_id():
+                self.data.token_id = proposal.action.unwrap.set_token_id()
+
+            if proposal.action.is_variant.set_fee_recipient():
+                self.data.fee_recipient = (
+                    proposal.action.unwrap.set_fee_recipient()
+                )
+
+            if proposal.action.is_variant.set_propose_edit_fee():
+                self.data.propose_edit_fee = (
+                    proposal.action.unwrap.set_propose_edit_fee()
+                )
+
+            if proposal.action.is_variant.set_propose_page_fee():
+                self.data.propose_page_fee = (
+                    proposal.action.unwrap.set_propose_page_fee()
+                )
+
+            if proposal.action.is_variant.update_metadata():
+                entry = proposal.action.unwrap.update_metadata()
+                self.data.metadata[entry.key] = entry.value
+
+        # =====================================================================
+        # Views
+        # =====================================================================
+
+        @sp.onchain_view()
+        def get_page(self, page_id):
+            """Returns the page record for a given page id."""
+            sp.cast(page_id, sp.nat)
+            assert page_id in self.data.pages, "WIKI_PAGE_NOT_FOUND"
+            return self.data.pages[page_id]
+
+        @sp.onchain_view()
+        def get_version(self, key):
+            """Returns a specific version of a page."""
+            sp.cast(key, version_key_type)
+            assert key in self.data.versions, "WIKI_VERSION_NOT_FOUND"
+            return self.data.versions[key]
+
+        @sp.onchain_view()
+        def get_page_count(self):
+            """Returns the total number of pages."""
+            return self.data.page_count
+
+        @sp.onchain_view()
+        def get_proposal(self, proposal_id):
+            """Returns community proposal record by ID."""
+            sp.cast(proposal_id, sp.nat)
+            assert proposal_id in self.data.proposals, "WIKI_NO_PROPOSAL"
+            return self.data.proposals[proposal_id]
+
+        @sp.onchain_view()
+        def get_proposal_count(self):
+            """Returns the total number of community proposals."""
+            return self.data.proposal_counter
+
+        @sp.onchain_view()
+        def get_fees(self):
+            """Returns the current per-action fees and fee recipient."""
+            return sp.record(
+                propose_edit_fee=self.data.propose_edit_fee,
+                propose_page_fee=self.data.propose_page_fee,
+                fee_recipient=self.data.fee_recipient,
+            )
+
+        @sp.onchain_view()
+        def get_governance_proposal(self, proposal_id):
+            """Get governance proposal by ID."""
+            sp.cast(proposal_id, sp.nat)
+            assert proposal_id in self.data.gov_proposals, "WIKI_NO_GOV_PROPOSAL"
+            return self.data.gov_proposals[proposal_id]
+
+        @sp.onchain_view()
+        def get_governance_vote(self, key):
+            """Get governance vote by key (proposal_id, voter)."""
+            sp.cast(key, gov_vote_key_type)
+            return self.data.gov_votes.get(key, default=False)
+
+
+# =============================================================================
+# Deployment Scenario
+# =============================================================================
+
+
+@sp.add_test()
+def deploy():
+    """Deployment scenario — generates compiled Michelson for origination."""
+    scenario = sp.test_scenario("deploy_wiki", wiki_module)
+    scenario.h1("Teia Wiki Contract — Deployment")
+
+    # =========================================================================
+    # DEPLOYMENT VALUES (Mainnet)
+    # =========================================================================
+    # Teia Core Team multisig
+    MULTISIG_ADDRESS = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    # Teia Moderator contract
+    MODERATOR_ADDRESS = sp.address("KT1RbVvb4eZh618krF49abrpEmAdb3zK92v6")
+    # Teia DAO token (NOT the distributor KT1NrfV...!)
+    TOKEN_ADDRESS = sp.address(
+        "KT1QrtA753MSv8VGxkDrKKyJniG5JtuHHbtV"
+    )
+    TOKEN_ID = sp.nat(0)
+    # Per-action fees start at 0 (free); the multisig can raise them later.
+    FEE_RECIPIENT = sp.address("KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb")
+    PROPOSE_EDIT_FEE = sp.mutez(0)
+    PROPOSE_PAGE_FEE = sp.mutez(0)
+    # =========================================================================
+
+    # =========================================================================
+    # MIGRATED PAGES (seeded into initial storage at origination)
+    # =========================================================================
+    # Copied verbatim from the previous slug-based wiki contract
+    # KT1BpPYWmzJiLjcBTYod5yHudkZ8ehSw2b2Q. The integer page_id mirrors that
+    # contract's page_slugs index (creation order), and the full version
+    # history is preserved with original editor/proposer/timestamp.
+    #   0 test-page                          5 z-test
+    #   1 edit-test-page                      6 teia-events
+    #   2 hide-test-page                      7 tezos-foundation-grant-events
+    #   3 teia-smart-contract-fees-list-test
+    #   4 alphabetical-test (hidden)
+    # Page names/titles now live off-chain in the CID content; the UI keeps the
+    # slug -> page_id mapping above.
+    SEED_PAGES = sp.big_map(
+        {
+            0: sp.record(  # test-page
+                current_cid="QmdCMH4o7ypRSqJUsKxfwdKMWzwU1PdHWUDGU9Vs5kE1rM",
+                hidden=False,
+                version_count=sp.nat(2),
+            ),
+            1: sp.record(  # edit-test-page
+                current_cid="QmQCiAcytcSCXMxzLC5FyAttFYMCLycTJXvcpiKNazUoWX",
+                hidden=False,
+                version_count=sp.nat(5),
+            ),
+            2: sp.record(  # hide-test-page
+                current_cid="QmeND5NzwoQJAtcJo1KydAFcU1HtbQEyS9gZbaomooUggD",
+                hidden=False,
+                version_count=sp.nat(2),
+            ),
+            3: sp.record(  # teia-smart-contract-fees-list-test
+                current_cid="QmdrU1mD2MVvN34oTgTAbD76Pi936C439SDFcTuUtWmRnS",
+                hidden=False,
+                version_count=sp.nat(2),
+            ),
+            4: sp.record(  # alphabetical-test
+                current_cid="QmTQuXoB5FNiFcCaGpzL8utM2JRz7M8GSVs5LnUDzKfb2R",
+                hidden=True,
+                version_count=sp.nat(1),
+            ),
+            5: sp.record(  # z-test
+                current_cid="QmQdxBVm6ygPXS26YJGxpZWoaEpT5rv4NtYEaRC2r5WNwR",
+                hidden=False,
+                version_count=sp.nat(4),
+            ),
+            6: sp.record(  # teia-events
+                current_cid="QmQ8sCNL2Hu287XBQnC2yigxdCTixW36iDfjEnQrZMHHD9",
+                hidden=False,
+                version_count=sp.nat(1),
+            ),
+            7: sp.record(  # tezos-foundation-grant-events
+                current_cid="QmUpFF9jkerWKRtsYYRTCu1kKZgB1AjksSfdLVv3RszFB8",
+                hidden=False,
+                version_count=sp.nat(1),
+            ),
+        }
+    )
+
+    SEED_VERSIONS = sp.big_map(
+        {
+            sp.record(page_id=sp.nat(0), version=sp.nat(1)): sp.record(
+                cid="QmVDFdpqLLN3YzwajJehE7edJh6WVksPV6oeNu4vxcfxig",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.Some(sp.address("tz1ZhteLTqobRVCYsPj44oFfom5BJ2SdGxeE")),
+                ts=sp.timestamp(1781534341),
+                version=sp.nat(1),
+            ),  # test-page v1
+            sp.record(page_id=sp.nat(0), version=sp.nat(2)): sp.record(
+                cid="QmdCMH4o7ypRSqJUsKxfwdKMWzwU1PdHWUDGU9Vs5kE1rM",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782222733),
+                version=sp.nat(2),
+            ),  # test-page v2
+            sp.record(page_id=sp.nat(1), version=sp.nat(1)): sp.record(
+                cid="QmUDV9VBEuRrDKywihiKyoR2aBGjHBbF4kekhFqvSjdXim",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781534587),
+                version=sp.nat(1),
+            ),  # edit-test-page v1
+            sp.record(page_id=sp.nat(1), version=sp.nat(2)): sp.record(
+                cid="QmeJfgTagWtcYyjZHdzDzzNmYnTfnNZp4WxHZSPi2rqnwo",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781534902),
+                version=sp.nat(2),
+            ),  # edit-test-page v2
+            sp.record(page_id=sp.nat(1), version=sp.nat(3)): sp.record(
+                cid="QmTQZ3LX3Zu2zCgdVzZnNxRceNPe4T9YCQUwNZptwMgLMo",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.Some(sp.address("tz1ZhteLTqobRVCYsPj44oFfom5BJ2SdGxeE")),
+                ts=sp.timestamp(1782147358),
+                version=sp.nat(3),
+            ),  # edit-test-page v3
+            sp.record(page_id=sp.nat(1), version=sp.nat(4)): sp.record(
+                cid="QmZEQY36Cfn95PJvmcYqfBLDB7nVUFCuJw9VEib9dbhReh",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782147400),
+                version=sp.nat(4),
+            ),  # edit-test-page v4
+            sp.record(page_id=sp.nat(1), version=sp.nat(5)): sp.record(
+                cid="QmQCiAcytcSCXMxzLC5FyAttFYMCLycTJXvcpiKNazUoWX",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782221995),
+                version=sp.nat(5),
+            ),  # edit-test-page v5
+            sp.record(page_id=sp.nat(2), version=sp.nat(1)): sp.record(
+                cid="QmVxcPsNJKzRTCQ8NLHWtyEfm8u2YdbQUgmhQVje7V1AfR",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781534734),
+                version=sp.nat(1),
+            ),  # hide-test-page v1
+            sp.record(page_id=sp.nat(2), version=sp.nat(2)): sp.record(
+                cid="QmeND5NzwoQJAtcJo1KydAFcU1HtbQEyS9gZbaomooUggD",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782223063),
+                version=sp.nat(2),
+            ),  # hide-test-page v2
+            sp.record(page_id=sp.nat(3), version=sp.nat(1)): sp.record(
+                cid="QmPhUnVHu9i3F2krkds2mBmStFY39v3hnYagFSLC8iecqz",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781535034),
+                version=sp.nat(1),
+            ),  # teia-smart-contract-fees-list-test v1
+            sp.record(page_id=sp.nat(3), version=sp.nat(2)): sp.record(
+                cid="QmdrU1mD2MVvN34oTgTAbD76Pi936C439SDFcTuUtWmRnS",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782223297),
+                version=sp.nat(2),
+            ),  # teia-smart-contract-fees-list-test v2
+            sp.record(page_id=sp.nat(4), version=sp.nat(1)): sp.record(
+                cid="QmTQuXoB5FNiFcCaGpzL8utM2JRz7M8GSVs5LnUDzKfb2R",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781535106),
+                version=sp.nat(1),
+            ),  # alphabetical-test v1
+            sp.record(page_id=sp.nat(5), version=sp.nat(1)): sp.record(
+                cid="Qmd8n9NcQVUeMb3DGKTyGGgdBHQG9i7Bs4j8N61a1DR8V2",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1781535148),
+                version=sp.nat(1),
+            ),  # z-test v1
+            sp.record(page_id=sp.nat(5), version=sp.nat(2)): sp.record(
+                cid="Qmed3kcUm9m4kyhL9mNy4eRpA2SueDhDtyLf44BMrY6ovx",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.Some(sp.address("tz1ZhteLTqobRVCYsPj44oFfom5BJ2SdGxeE")),
+                ts=sp.timestamp(1782147463),
+                version=sp.nat(2),
+            ),  # z-test v2
+            sp.record(page_id=sp.nat(5), version=sp.nat(3)): sp.record(
+                cid="Qmf12ozyd94WYVqXNWpceRhGjebUtBXW4FNWuKBU1nLsUN",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782147499),
+                version=sp.nat(3),
+            ),  # z-test v3
+            sp.record(page_id=sp.nat(5), version=sp.nat(4)): sp.record(
+                cid="QmQdxBVm6ygPXS26YJGxpZWoaEpT5rv4NtYEaRC2r5WNwR",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782223561),
+                version=sp.nat(4),
+            ),  # z-test v4
+            sp.record(page_id=sp.nat(6), version=sp.nat(1)): sp.record(
+                cid="QmQ8sCNL2Hu287XBQnC2yigxdCTixW36iDfjEnQrZMHHD9",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782169357),
+                version=sp.nat(1),
+            ),  # teia-events v1
+            sp.record(page_id=sp.nat(7), version=sp.nat(1)): sp.record(
+                cid="QmUpFF9jkerWKRtsYYRTCu1kKZgB1AjksSfdLVv3RszFB8",
+                editor=sp.address("tz1ZVzMVj6EjRoDNFMCguG7nGdqmD7aau9kS"),
+                proposer=sp.cast(None, sp.option[sp.address]),
+                ts=sp.timestamp(1782312193),
+                version=sp.nat(1),
+            ),  # tezos-foundation-grant-events v1
+        }
+    )
+
+    SEED_PAGE_COUNT = sp.nat(8)
+
+    contract_metadata = sp.big_map(
+        {
+            "": sp.scenario_utils.bytes_of_string(
+                "ipfs://QmYBKZjoqvi3qV8ZLaQpRPE5AacQLRoULaCnW613g9hzMG"
+            ),
+        }
+    )
+
+    contract = wiki_module.Wiki(
+        metadata=contract_metadata,
+        moderator_address=MODERATOR_ADDRESS,
+        multisig_address=MULTISIG_ADDRESS,
+        token_address=TOKEN_ADDRESS,
+        token_id=TOKEN_ID,
+        fee_recipient=FEE_RECIPIENT,
+        propose_edit_fee=PROPOSE_EDIT_FEE,
+        propose_page_fee=PROPOSE_PAGE_FEE,
+        pages=SEED_PAGES,
+        versions=SEED_VERSIONS,
+        page_count=SEED_PAGE_COUNT,
+        gov_counter=sp.nat(0),
+    )
+    scenario += contract
+
+    scenario.h2("Contract deployed with:")
+    scenario.show(MULTISIG_ADDRESS)
+    scenario.show(MODERATOR_ADDRESS)
+    scenario.show(TOKEN_ADDRESS)


### PR DESCRIPTION
The Teia community wiki. Each page is identified by an auto-incrementing page_id and stores its current IPFS/Arweave CID, a hidden flag, and a full append-only version history. Page names/titles live off-chain in the CID content.

Moderators and linked multisig users can create, update, and hide pages directly; Teia token holders can propose edits to existing pages or brand new pages, each proposal charging its own configurable fee and applied by a single moderator/multisig approval. Multisig governance covers pause, linked addresses, token id, per-action fees, fee recipient, and metadata updates, with vote threshold and expiration fetched from the linked multisig.